### PR TITLE
EMP-11070 Bugfix AVPlayer: Rapid consecutive seek(toTime:) events may…

### DIFF
--- a/ExposurePlayback/Protocols/ContextGoLive.swift
+++ b/ExposurePlayback/Protocols/ContextGoLive.swift
@@ -33,6 +33,14 @@ extension ContextGoLive {
             }
         }
         
+        if let serverTime = player.serverTime, last > serverTime {
+            /// It is impossible to search beyond the actual live point
+            let warning = PlayerWarning<HLSNative<ExposureContext>, ExposureContext>.tech(warning: .seekTimeBeyondLivePoint(timestamp: last, livePoint: serverTime))
+            player.tech.eventDispatcher.onWarning(player.tech, player.tech.currentSource, warning)
+            player.tech.currentSource?.analyticsConnector.onWarning(tech: player.tech, source: player.tech.currentSource, warning: warning)
+            return
+        }
+        
         if let programService = player.context.programService {
             programService.isEntitled(toPlay: last) { program in
                 // NOTE: If `callback` is NOT fired:


### PR DESCRIPTION
… cause the AVPlayer to loose its sync between currentTime and currentDate. We use both internally to map seekableRange to seekableTimeRange (and bufferedRange to bufferedTimeRange). This causes an incorrect "last seekable unix timestamp" to be reported with a subsequent entitlement call on a program for a timestamp in the future.

Solution is to limit the seekToLive functionality to serverTime if available. If the last reported seekableTime position is beyond serverTime, this seek is disregarded with an error being thrown.