### PR TITLE
Migrate to v2 of playAsset API - Emp 12365

### DIFF
--- a/ExposurePlayback.xcodeproj/project.pbxproj
+++ b/ExposurePlayback.xcodeproj/project.pbxproj
@@ -284,6 +284,8 @@
 		76EBF03A215E3E0600503146 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EBF039215E3E0600503146 /* Reachability.swift */; };
 		76EBF03B215E3E0600503146 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EBF039215E3E0600503146 /* Reachability.swift */; };
 		76FA63BE203CD177000209B7 /* HLSNative+ExposureContext+TrackSelectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FA63BD203CD177000209B7 /* HLSNative+ExposureContext+TrackSelectable.swift */; };
+		781341A5228014B800ECAC6B /* SelectionTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781341A4228014B800ECAC6B /* SelectionTableViewController.swift */; };
+		781341A7228028D800ECAC6B /* EPGListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781341A6228028D800ECAC6B /* EPGListViewController.swift */; };
 		7831FACA2264AEF700743D07 /* PlayBackEntitlementV2+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7831FAC92264AEF700743D07 /* PlayBackEntitlementV2+Extensions.swift */; };
 		7831FACB2264AEF700743D07 /* PlayBackEntitlementV2+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7831FAC92264AEF700743D07 /* PlayBackEntitlementV2+Extensions.swift */; };
 		784E3AD321B16B0A00C986CF /* RBMPlayerControlLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784E3AD221B16B0A00C986CF /* RBMPlayerControlLabel.swift */; };
@@ -524,6 +526,8 @@
 		76EBF036215E30E000503146 /* ConnectionChanged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionChanged.swift; sourceTree = "<group>"; };
 		76EBF039215E3E0600503146 /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		76FA63BD203CD177000209B7 /* HLSNative+ExposureContext+TrackSelectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HLSNative+ExposureContext+TrackSelectable.swift"; sourceTree = "<group>"; };
+		781341A4228014B800ECAC6B /* SelectionTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionTableViewController.swift; sourceTree = "<group>"; };
+		781341A6228028D800ECAC6B /* EPGListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPGListViewController.swift; sourceTree = "<group>"; };
 		7831FAC92264AEF700743D07 /* PlayBackEntitlementV2+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlayBackEntitlementV2+Extensions.swift"; sourceTree = "<group>"; };
 		784E3AD221B16B0A00C986CF /* RBMPlayerControlLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RBMPlayerControlLabel.swift; sourceTree = "<group>"; };
 		784E3AD621B16B5B00C986CF /* VodBasedTimeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VodBasedTimeline.swift; sourceTree = "<group>"; };
@@ -1027,7 +1031,9 @@
 			children = (
 				785B382021A59CB700FB7C7B /* EnvironmentViewController.swift */,
 				78D236DC21ABFEFC00E366B0 /* LoginViewController.swift */,
+				781341A4228014B800ECAC6B /* SelectionTableViewController.swift */,
 				78D236E621AD2F0600E366B0 /* AssetListTableViewController.swift */,
+				781341A6228028D800ECAC6B /* EPGListViewController.swift */,
 				9B17CE05218B3F17009C95C4 /* PlayerViewController.swift */,
 				78DE9FD621B9362C00C24CDE /* TrackSelectionViewController.swift */,
 			);
@@ -1473,7 +1479,9 @@
 				78DE9FD721B9362C00C24CDE /* TrackSelectionViewController.swift in Sources */,
 				785B380821A41AC500FB7C7B /* IbcScheme.swift in Sources */,
 				78A90C5421C7C87B00B3B626 /* UIViewController+Toast.swift in Sources */,
+				781341A5228014B800ECAC6B /* SelectionTableViewController.swift in Sources */,
 				784E3AD921B16B6E00C986CF /* ProgramBasedTimeline.swift in Sources */,
+				781341A7228028D800ECAC6B /* EPGListViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ExposurePlayback.xcodeproj/project.pbxproj
+++ b/ExposurePlayback.xcodeproj/project.pbxproj
@@ -284,6 +284,8 @@
 		76EBF03A215E3E0600503146 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EBF039215E3E0600503146 /* Reachability.swift */; };
 		76EBF03B215E3E0600503146 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EBF039215E3E0600503146 /* Reachability.swift */; };
 		76FA63BE203CD177000209B7 /* HLSNative+ExposureContext+TrackSelectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FA63BD203CD177000209B7 /* HLSNative+ExposureContext+TrackSelectable.swift */; };
+		7831FACA2264AEF700743D07 /* PlayBackEntitlementV2+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7831FAC92264AEF700743D07 /* PlayBackEntitlementV2+Extensions.swift */; };
+		7831FACB2264AEF700743D07 /* PlayBackEntitlementV2+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7831FAC92264AEF700743D07 /* PlayBackEntitlementV2+Extensions.swift */; };
 		784E3AD321B16B0A00C986CF /* RBMPlayerControlLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784E3AD221B16B0A00C986CF /* RBMPlayerControlLabel.swift */; };
 		784E3AD721B16B5B00C986CF /* VodBasedTimeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784E3AD621B16B5B00C986CF /* VodBasedTimeline.swift */; };
 		784E3AD921B16B6E00C986CF /* ProgramBasedTimeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784E3AD821B16B6E00C986CF /* ProgramBasedTimeline.swift */; };
@@ -308,6 +310,8 @@
 		78DE9FD721B9362C00C24CDE /* TrackSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DE9FD621B9362C00C24CDE /* TrackSelectionViewController.swift */; };
 		78DE9FDA21BA650800C24CDE /* TrackSelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DE9FD921BA650800C24CDE /* TrackSelectionViewModel.swift */; };
 		78DE9FDD21BA654500C24CDE /* TrackModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DE9FDC21BA654500C24CDE /* TrackModel.swift */; };
+		78DF4A0B225CD66300B8348A /* PlaybackEntitlementV2+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DF4A0A225CD66300B8348A /* PlaybackEntitlementV2+Extension.swift */; };
+		78DF4A1B225F239800B8348A /* EnigmaPlayable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DF4A1A225F239800B8348A /* EnigmaPlayable.swift */; };
 		9B17CDFC2189EC4D009C95C4 /* UIImageView+constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B17CDFB2189EC4D009C95C4 /* UIImageView+constraint.swift */; };
 		9B17CE06218B3F17009C95C4 /* PlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B17CE05218B3F17009C95C4 /* PlayerViewController.swift */; };
 /* End PBXBuildFile section */
@@ -520,6 +524,7 @@
 		76EBF036215E30E000503146 /* ConnectionChanged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionChanged.swift; sourceTree = "<group>"; };
 		76EBF039215E3E0600503146 /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		76FA63BD203CD177000209B7 /* HLSNative+ExposureContext+TrackSelectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HLSNative+ExposureContext+TrackSelectable.swift"; sourceTree = "<group>"; };
+		7831FAC92264AEF700743D07 /* PlayBackEntitlementV2+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlayBackEntitlementV2+Extensions.swift"; sourceTree = "<group>"; };
 		784E3AD221B16B0A00C986CF /* RBMPlayerControlLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RBMPlayerControlLabel.swift; sourceTree = "<group>"; };
 		784E3AD621B16B5B00C986CF /* VodBasedTimeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VodBasedTimeline.swift; sourceTree = "<group>"; };
 		784E3AD821B16B6E00C986CF /* ProgramBasedTimeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramBasedTimeline.swift; sourceTree = "<group>"; };
@@ -544,6 +549,8 @@
 		78DE9FD621B9362C00C24CDE /* TrackSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSelectionViewController.swift; sourceTree = "<group>"; };
 		78DE9FD921BA650800C24CDE /* TrackSelectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSelectionViewModel.swift; sourceTree = "<group>"; };
 		78DE9FDC21BA654500C24CDE /* TrackModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackModel.swift; sourceTree = "<group>"; };
+		78DF4A0A225CD66300B8348A /* PlaybackEntitlementV2+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaybackEntitlementV2+Extension.swift"; sourceTree = "<group>"; };
+		78DF4A1A225F239800B8348A /* EnigmaPlayable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnigmaPlayable.swift; sourceTree = "<group>"; };
 		9B17CDFB2189EC4D009C95C4 /* UIImageView+constraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+constraint.swift"; sourceTree = "<group>"; };
 		9B17CE05218B3F17009C95C4 /* PlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -740,6 +747,7 @@
 				7686A8BF2040281C0002E2B6 /* LanguagePreferencesSpec.swift */,
 				76D5C9DD20304C1E0056BFF8 /* MockedAVPlayer.swift */,
 				76D5C9DF20304EBA0056BFF8 /* PlaybackEntitlement+Extensions.swift */,
+				7831FAC92264AEF700743D07 /* PlayBackEntitlementV2+Extensions.swift */,
 				76D5C9E12030559D0056BFF8 /* Program+Extensions.swift */,
 				76D5C9E3203199DF0056BFF8 /* EntitlementValidation+Extensions.swift */,
 				7636CA9D2031DB9A00F914D1 /* ServerTime+Extensions.swift */,
@@ -821,6 +829,7 @@
 				76A89C3820207AB100C23579 /* AssetPlayable.swift */,
 				76A89C3920207AB100C23579 /* ChannelPlayable.swift */,
 				76A89C3A20207AB100C23579 /* ProgramPlayable.swift */,
+				78DF4A1A225F239800B8348A /* EnigmaPlayable.swift */,
 			);
 			path = Playable;
 			sourceTree = "<group>";
@@ -905,6 +914,7 @@
 				76A89D642020F36400C23579 /* UIDevice+Extensions.swift */,
 				7635AEC4202ADFDE001512BF /* CMTime+Extensions.swift */,
 				766FE470203B0563003B9B90 /* PlaybackEntitlement+Extensions.swift */,
+				78DF4A0A225CD66300B8348A /* PlaybackEntitlementV2+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1471,6 +1481,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78DF4A0B225CD66300B8348A /* PlaybackEntitlementV2+Extension.swift in Sources */,
 				76A89C4E20207AB200C23579 /* MRRFairplayRequester.swift in Sources */,
 				76A89D992020F41F00C23579 /* Paused.swift in Sources */,
 				76A89C5020207AB200C23579 /* ChannelPlayable.swift in Sources */,
@@ -1478,8 +1489,10 @@
 				76A89C4D20207AB200C23579 /* ExposureContext.swift in Sources */,
 				7635AEC5202ADFDE001512BF /* CMTime+Extensions.swift in Sources */,
 				76A89D9F2020F41F00C23579 /* ScrubbedTo.swift in Sources */,
+				7831FACA2264AEF700743D07 /* PlayBackEntitlementV2+Extensions.swift in Sources */,
 				76FA63BE203CD177000209B7 /* HLSNative+ExposureContext+TrackSelectable.swift in Sources */,
 				7635AEC9202AE0A2001512BF /* ContextTimeSeekable.swift in Sources */,
+				78DF4A1B225F239800B8348A /* EnigmaPlayable.swift in Sources */,
 				76010C872125B364008DB688 /* StopAirplay.swift in Sources */,
 				76A89D8C2020F41F00C23579 /* Completed.swift in Sources */,
 				76A89D962020F41F00C23579 /* HandshakeStarted.swift in Sources */,
@@ -1573,6 +1586,7 @@
 				76458ABD204D3212002AB3FB /* SeekToLiveMock.swift in Sources */,
 				76A89DF12021CCC000C23579 /* HandshakeStartedSpec.swift in Sources */,
 				76A89DF62021CCC000C23579 /* ProgramChangedSpec.swift in Sources */,
+				7831FACB2264AEF700743D07 /* PlayBackEntitlementV2+Extensions.swift in Sources */,
 				76D5C9E020304EBA0056BFF8 /* PlaybackEntitlement+Extensions.swift in Sources */,
 				76A89DF02021CCC000C23579 /* ErrorSpec.swift in Sources */,
 				7624D5FA20344BE300CD1835 /* ChannelSource+SeekToLive.swift in Sources */,

--- a/ExposurePlayback/Context/Playable/AssetPlayable.swift
+++ b/ExposurePlayback/Context/Playable/AssetPlayable.swift
@@ -178,10 +178,10 @@ extension AssetPlayable {
                 
                 // Live event - TODO
                 if value.streamInfo.event == true {
-                    print("This is a live event , handle accordingly :- handle as a normal program for now ")
+                    print("This is a live event , handle accordingly :- handle as a normal program for now 7")
                     let source = ProgramSource(entitlement: playbackEntitlement, assetId: self.assetId, channelId: value.streamInfo.channelId ?? "", streamingInfo: value.streamInfo)
                     source.response = response
-                    callback(source, nil)
+                    callback(source, nil, response)
                 }
                    
                 // Dynamic catchup as live

--- a/ExposurePlayback/Context/Playable/AssetPlayable.swift
+++ b/ExposurePlayback/Context/Playable/AssetPlayable.swift
@@ -101,9 +101,12 @@ extension AssetPlayable {
                     return
                 }
                 
-                // Live event :- ToDo
+                // Live event :- TODO
                 if value.streamInfo.event == true {
-                    print("This is a live event handle accordingly")
+                    print("This is a live event handle accordingly : handle as a normal program for now ")
+                    let source = ProgramSource(entitlement: playbackEntitlement, assetId: self.assetId, channelId: value.streamInfo.channelId ?? "", streamingInfo: value.streamInfo)
+                    source.response = response
+                    callback(source, nil)
                 }
                 
                 // This is a live program
@@ -175,7 +178,10 @@ extension AssetPlayable {
                 
                 // Live event - TODO
                 if value.streamInfo.event == true {
-                    print("This is a live event , handle accordingly")
+                    print("This is a live event , handle accordingly :- handle as a normal program for now ")
+                    let source = ProgramSource(entitlement: playbackEntitlement, assetId: self.assetId, channelId: value.streamInfo.channelId ?? "", streamingInfo: value.streamInfo)
+                    source.response = response
+                    callback(source, nil)
                 }
                    
                 // Dynamic catchup as live

--- a/ExposurePlayback/Context/Playable/ChannelPlayable.swift
+++ b/ExposurePlayback/Context/Playable/ChannelPlayable.swift
@@ -9,8 +9,14 @@
 import Foundation
 import Exposure
 
+
+
+/// This should be deprecated when the all customers ( Thuis ) moved to AssetPlayable()
 internal protocol ChannelEntitlementProvider {
+    
     func requestEntitlement(channelId: String, using sessionToken: SessionToken, in environment: Environment, callback: @escaping (PlaybackEntitlement?, ExposureError?, HTTPURLResponse?) -> Void)
+    
+    func requestEntitlementV2(channelId: String, using sessionToken: SessionToken, in environment: Environment, callback: @escaping (PlaybackEntitlement?, PlayBackEntitlementV2?, ExposureError?, HTTPURLResponse?) -> Void)
 }
 
 /// Defines a `Playable` for the specific channel. Will play the currently live program
@@ -22,31 +28,56 @@ public struct ChannelPlayable: Playable {
     
     internal struct ExposureEntitlementProvider: ChannelEntitlementProvider {
         func requestEntitlement(channelId: String, using sessionToken: SessionToken, in environment: Environment, callback: @escaping (PlaybackEntitlement?, ExposureError?, HTTPURLResponse?) -> Void) {
-            let entitlement = Entitlement(environment: environment,
-                                          sessionToken: sessionToken)
-                .live(channelId: channelId)
             
-            entitlement
+            self.requestEntitlementV2(channelId: channelId, using: sessionToken, in: environment, callback: { entitlementV1, entitlementV2, error, response in
+                
+                guard let entitlementV2 = entitlementV2 else { return
+                    callback(nil, error, response)
+                }
+                let (convertedEntitlement, error ) = EnigmaPlayable.convertV2EntitlementToV1(entitlementV2: entitlementV2)
+                
+                guard let playbackEntitlement = convertedEntitlement else {
+                    callback(nil, error, response)
+                    return
+                }
+                
+                callback(playbackEntitlement, error, response )
+                
+            })
+            
+        }
+        
+        
+        
+        /// Request entitlement V2 & convert it to playback entitlement v1
+        ///
+        /// - Parameters:
+        ///   - channelId: channel Id
+        ///   - sessionToken: session token
+        ///   - environment: exposure enviornment
+        ///   - callback: callback
+        func requestEntitlementV2(channelId: String, using sessionToken: SessionToken, in environment: Environment, callback: @escaping (PlaybackEntitlement?, PlayBackEntitlementV2?, ExposureError?, HTTPURLResponse?) -> Void) {
+            
+            Entitlement(environment: environment,
+                        sessionToken: sessionToken)
+                .enigmaAsset(assetId: channelId)
                 .request()
                 .validate()
                 .response{
-                    if let error = $0.error {
-                        // Workaround until EMP-10023 is fixed
-                        if case let .exposureResponse(reason: reason) = error, (reason.httpCode == 403 && reason.message == "NO_MEDIA_ON_CHANNEL") {
-                            entitlement
-                                .use(drm: "UNENCRYPTED")
-                                .request()
-                                .validate()
-                                .response{ callback($0.value, $0.error, $0.response) }
-                        }
-                        else {
-                            callback($0.value, $0.error, $0.response)
-                        }
+                    guard let enetitlementV2Response =  $0.value else {
+                        callback(nil,nil, $0.error, $0.response)
+                        return
                     }
-                    else {
-                        callback($0.value, $0.error, $0.response)
+                    
+                    let (convertedEntitlement, error) = EnigmaPlayable.convertV2EntitlementToV1(entitlementV2: enetitlementV2Response)
+                    guard let playbackEntitlement = convertedEntitlement else {
+                        callback(nil,nil, error, $0.response)
+                        return
                     }
-                }
+                    
+                    
+                    callback(playbackEntitlement, enetitlementV2Response, $0.error, $0.response)
+            }
         }
     }
 }
@@ -68,14 +99,24 @@ extension ChannelPlayable {
     }
     
     internal func prepareChannelSource(environment: Environment, sessionToken: SessionToken, callback: @escaping (ExposureSource?, ExposureError?) -> Void) {
-        entitlementProvider.requestEntitlement(channelId: assetId, using: sessionToken, in: environment) { entitlement, error, response in
-            if let value = entitlement {
-                let source = ChannelSource(entitlement: value, assetId: self.assetId)
+        entitlementProvider.requestEntitlementV2(channelId: assetId, using: sessionToken, in: environment) { entitlementV1, entitlementV2, error, response in
+            if let value = entitlementV2 {
+                
+                guard let playbackEntitlement = entitlementV1 else {
+                    callback(nil, error)
+                    return
+                }
+                
+                let source = ChannelSource(entitlement: playbackEntitlement, assetId: self.assetId, streamingInfo: value.streamInfo)
                 source.response = response
                 callback(source, nil)
             }
             else if let error = error {
                 callback(nil,error)
+            }
+            else {
+                print("Some unkown error occured while prepareChannelSource in ChannelPlayable")
+                callback(nil,nil)
             }
         }
     }
@@ -83,16 +124,25 @@ extension ChannelPlayable {
 
 extension ChannelPlayable {
     public func prepareSourceWithResponse(environment: Environment, sessionToken: SessionToken, callback: @escaping (ExposureSource?, ExposureError?, HTTPURLResponse?) -> Void) {
-        entitlementProvider.requestEntitlement(channelId: assetId, using: sessionToken, in: environment) { entitlement, error, response in
-            if let value = entitlement {
-                let source = ChannelSource(entitlement: value, assetId: self.assetId)
+        entitlementProvider.requestEntitlementV2(channelId: assetId, using: sessionToken, in: environment) { entitlementV1, entitlementV2, error, response in
+            if let value = entitlementV2 {
+                
+                guard let playbackEntitlement = entitlementV1 else {
+                    callback(nil, error, response)
+                    return
+                }
+                
+                let source = ChannelSource(entitlement: playbackEntitlement, assetId: self.assetId, streamingInfo: value.streamInfo)
                 source.response = response
                 callback(source, nil, response)
             }
             else if let error = error {
                 callback(nil,error,response)
             }
+            else {
+                print("Some unkown error occured while prepareSourceWithResponse in ChannelPlayable")
+                callback(nil,nil,response)
+            }
         }
     }
 }
-

--- a/ExposurePlayback/Context/Playable/EnigmaPlayable.swift
+++ b/ExposurePlayback/Context/Playable/EnigmaPlayable.swift
@@ -1,0 +1,87 @@
+//
+//  Playable.swift
+//  ExposurePlayback-iOS
+//
+//  Created by Udaya Sri Senarathne on 2019-04-10.
+//  Copyright © 2019 emp. All rights reserved.
+//
+
+import Foundation
+import Exposure
+
+public struct EnigmaPlayable {
+    /// Convert EntitlementPlay V2 response to EntitlementPlayV1
+    ///
+    /// - Parameter entitlementV2: response from play V2
+    /// - Returns: Entitlement & error
+    internal static func convertV2EntitlementToV1(entitlementV2: PlayBackEntitlementV2 ) -> (PlaybackEntitlement?, ExposureError? ) {
+        
+        guard let format = entitlementV2.formats?.first else {
+            let noSupportedMediaFormatsError = NSError(domain: "Could not find a media format supported by the current player implementation.", code: 38, userInfo: nil)
+            
+            return (nil, ExposureError.generalError(error: noSupportedMediaFormatsError))
+        }
+        
+//        guard let certificateUrl = format.fairplay.first?.certificateUrl, let licenseServerUrl = format.fairplay.first?.licenseServerUrl else {
+//            let noSupportedMediaFormatsError = NSError(domain: "Can not find certificate url or licenseAcquisition url", code: 38, userInfo: nil)
+//            return (nil, ExposureError.generalError(error: noSupportedMediaFormatsError))
+//        }
+        
+        let certificateUrl = format.fairplay.first?.certificateUrl
+        let licenseServerUrl = format.fairplay.first?.licenseServerUrl
+        
+        let fairplay = FairplayConfiguration(secondaryMediaLocator: nil, certificateUrl: certificateUrl, licenseAcquisitionUrl: licenseServerUrl, licenseServerUrl: licenseServerUrl)
+        
+        let playbackEntitlement = PlaybackEntitlement(
+            playTokenExpiration: String(entitlementV2.playTokenExpiration),
+            mediaLocator: (format.mediaLocator),
+            playSessionId: entitlementV2.playSessionId,
+            live: entitlementV2.streamInfo.live ?? false,
+            ffEnabled: entitlementV2.contractRestrictions?.ffEnabled ?? true,
+            timeshiftEnabled: entitlementV2.contractRestrictions?.timeshiftEnabled ?? true,
+            rwEnabled: entitlementV2.contractRestrictions?.rwEnabled ?? true,
+            airplayBlocked: entitlementV2.contractRestrictions?.airplayEnabled ?? true,
+            playToken: entitlementV2.playToken,
+            fairplay: fairplay,
+            licenseExpiration: nil,
+            licenseExpirationReason: nil,
+            licenseActivation: nil, entitlementType: entitlementV2.entitlementType,
+            minBitrate: entitlementV2.contractRestrictions?.minBitrate ?? 0,
+            maxBitrate: entitlementV2.contractRestrictions?.maxBitrate ?? 0,
+            maxResHeight: entitlementV2.contractRestrictions?.maxResHeight ?? 0,
+            mdnRequestRouterUrl: nil,
+            lastViewedOffset: entitlementV2.bookmarks?.lastViewedOffset ?? nil ,
+            lastViewedTime: entitlementV2.bookmarks?.lastViewedTime ?? nil,
+            liveTime: entitlementV2.bookmarks?.liveTime ?? nil ,
+            productId: entitlementV2.productId,
+            adMediaLocator: nil)
+        
+        return (playbackEntitlement, nil)
+    }
+    
+    
+    /*
+    /// Convert json data to String json :- Testing purposes
+    ///
+    /// - Parameters:
+    ///   - json: <#json description#>
+    ///   - prettyPrinted: <#prettyPrinted description#>
+    /// - Returns: <#return value description#>
+    static func stringify(json: Any, prettyPrinted: Bool = false) -> String {
+        var options: JSONSerialization.WritingOptions = []
+        if prettyPrinted {
+            options = JSONSerialization.WritingOptions.prettyPrinted
+        }
+        
+        do {
+            let data = try JSONSerialization.data(withJSONObject: json, options: options)
+            if let string = String(data: data, encoding: String.Encoding.utf8) {
+                return string
+            }
+        } catch {
+            print(error)
+        }
+        
+        return ""
+    } */
+}

--- a/ExposurePlayback/Context/Playable/ProgramPlayable.swift
+++ b/ExposurePlayback/Context/Playable/ProgramPlayable.swift
@@ -68,14 +68,18 @@ public struct ProgramPlayable: Playable {
         ///   - programId: program id
         ///   - callback: call back will return assetId, exposure error & response
         internal func getAssetId(environment: Environment, sessionToken: SessionToken, channelId: String, programId: String, callback: @escaping (String?, ExposureError?, HTTPURLResponse?) -> Void) {
-            ExposureApi<EPGResponse>(environment: environment, endpoint: "/epg/"+channelId+"/program/"+programId, query: "onlyPublished=true&&includeUserData=false", method: .get, sessionToken: sessionToken)
+            
+            FetchEpg(environment: environment)
+                .channel(id: channelId, programId: programId)
                 .request()
+                .validate()
                 .response{
                     guard let asset =  $0.value?.asset else {
                         callback(nil, $0.error, $0.response )
                         return
                     }
                     callback(asset.assetId, nil, $0.response )
+
             }
         }
         

--- a/ExposurePlayback/Context/Source/ExposureSource.swift
+++ b/ExposurePlayback/Context/Source/ExposureSource.swift
@@ -44,18 +44,21 @@ open class ExposureSource: MediaSource {
     /// Service that manages contract restrictions
     public var contractRestrictionsService: ContractRestrictionsService
     
+    public var streamingInfo: StreamInfo?
+    
     /// Creates a new `ExposureSource`
     ///
     /// - note: Creation of *raw* `ExposureSource`s is discouraged. Please use the specialized subclasses such as `AssetSource`, `ProgramSource` or `ChannelSource`
     ///
     /// - parameter entitlement: `PlaybackEntitlement` used to play the asset
     /// - parameter assetId: The id for the asset
-    public init(entitlement: PlaybackEntitlement, assetId: String) {
+    public init(entitlement: PlaybackEntitlement, assetId: String, streamingInfo: StreamInfo?) {
         self.entitlement = entitlement
         self.assetId = assetId
         self.fairplayRequester = entitlement.isUnifiedPackager ? EMUPFairPlayRequester(entitlement: entitlement) : MRRFairplayRequester(entitlement: entitlement)
         self.contractRestrictionsService = BasicContractRestrictions(entitlement: entitlement)
         self.mediaSourceRequestHeaders = [:]
+        self.streamingInfo = streamingInfo
         self.response = nil
     }
     
@@ -66,7 +69,7 @@ open class ExposureSource: MediaSource {
     /// - parameter entitlement: `PlaybackEntitlement` used to play the asset
     /// - parameter assetId: The id for the asset
     /// - parameter response: HTTP response received when requesting the entitlement
-    public init(entitlement: PlaybackEntitlement, assetId: String, response: HTTPURLResponse?) {
+    public init(entitlement: PlaybackEntitlement, assetId: String, response: HTTPURLResponse?, streamingInfo: StreamInfo?) {
         self.entitlement = entitlement
         self.assetId = assetId
         self.fairplayRequester = entitlement.isUnifiedPackager ? EMUPFairPlayRequester(entitlement: entitlement) : MRRFairplayRequester(entitlement: entitlement)

--- a/ExposurePlayback/Context/Source/ProgramSource.swift
+++ b/ExposurePlayback/Context/Source/ProgramSource.swift
@@ -27,9 +27,9 @@ open class ProgramSource: ExposureSource {
     /// - parameter entitlement: `PlaybackEntitlement` used to play the program
     /// - parameter assetId: The id for the program
     /// - parameter channelId: The channel Id on which the program plays
-    public init(entitlement: PlaybackEntitlement, assetId: String, channelId: String) {
+    public init(entitlement: PlaybackEntitlement, assetId: String, channelId: String, streamingInfo: StreamInfo?) {
         self.channelId = channelId
-        super.init(entitlement: entitlement, assetId: assetId)
+        super.init(entitlement: entitlement, assetId: assetId, streamingInfo: streamingInfo)
     }
     
     /// Creates a new `ProgramSource`
@@ -38,9 +38,9 @@ open class ProgramSource: ExposureSource {
     /// - parameter assetId: The id for the program
     /// - parameter channelId: The channel Id on which the program plays
     /// - parameter response: HTTP response received when requesting the entitlement
-    public init(entitlement: PlaybackEntitlement, assetId: String, channelId: String, response: HTTPURLResponse? = nil) {
+    public init(entitlement: PlaybackEntitlement, assetId: String, channelId: String, response: HTTPURLResponse? = nil, streamingInfo: StreamInfo?) {
         self.channelId = channelId
-        super.init(entitlement: entitlement, assetId: assetId, response: response)
+        super.init(entitlement: entitlement, assetId: assetId, response: response, streamingInfo: streamingInfo)
     }
     
     public override func prepareSourceUrl(callback: @escaping (URL?) -> Void) {

--- a/ExposurePlayback/Extensions/PlaybackEntitlementV2+Extension.swift
+++ b/ExposurePlayback/Extensions/PlaybackEntitlementV2+Extension.swift
@@ -1,0 +1,24 @@
+//
+//  PlaybackEntitlementV2+Extension.swift
+//  ExposurePlayback-iOS
+//
+//  Created by Udaya Sri Senarathne on 2019-04-09.
+//  Copyright © 2019 emp. All rights reserved.
+//
+
+import Foundation
+import Exposure
+
+extension PlayBackEntitlementV2 {
+    /// Checks if the manifest comes from the *Unified Packager*
+    internal var isUnifiedPackager: Bool {
+        
+        guard let mediaLocator = formats?.first?.mediaLocator else {
+            return false
+        }
+        return mediaLocator
+            .pathComponents
+            .reduce(false) { $0 || $1.contains(".isml") || $1.contains(".ism") }
+    }
+}
+

--- a/ExposurePlaybackTests/BitrateRestrictionsSpec.swift
+++ b/ExposurePlaybackTests/BitrateRestrictionsSpec.swift
@@ -59,11 +59,24 @@ class BitrateRestrictionSpec: QuickSpec {
                 
                 // Configure the playable
                 let provider = MockedProgramEntitlementProvider()
-                provider.mockedRequestEntitlement = { _,_,_, callback in
+                provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                     var json = PlaybackEntitlement.requiedJson
                     json["mediaLocator"] = "file://play/.isml"
                     json["playSessionId"] = "BitrateSession"
-                    callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                    
+                    let streamInfo: [String: Any] = [
+                        "live" : false,
+                        "static" : false,
+                        "event" : false,
+                        "start" : 0,
+                        "channelId" : "channelId",
+                        "programId" : "programId"
+                    ]
+                    
+                    var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                    entitlementVersion2Json["streamInfo"] = streamInfo
+                    entitlementVersion2Json["playSessionId"] = "BitrateSession"
+                    callback(json.decode(PlaybackEntitlement.self),entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                 }
                 let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                 let properties = PlaybackProperties(maxBitrate: preferredBitRate)

--- a/ExposurePlaybackTests/LanguagePreferencesSpec.swift
+++ b/ExposurePlaybackTests/LanguagePreferencesSpec.swift
@@ -61,11 +61,12 @@ class LanguagePreferencesSpec: QuickSpec {
                         
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["playSessionId"] = "playSessionId"
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            callback(json.decode(PlaybackEntitlement.self),PlayBackEntitlementV2.requiedJson.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         let properties = PlaybackProperties(language: .defaultBehaviour)
@@ -104,11 +105,11 @@ class LanguagePreferencesSpec: QuickSpec {
                         
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["playSessionId"] = "playSessionId"
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            callback(json.decode(PlaybackEntitlement.self), PlayBackEntitlementV2.requiedJson.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         let properties = PlaybackProperties(language: .userLocale)
@@ -147,11 +148,11 @@ class LanguagePreferencesSpec: QuickSpec {
                         
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["playSessionId"] = "playSessionId"
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            callback(json.decode(PlaybackEntitlement.self), PlayBackEntitlementV2.requiedJson.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         let properties = PlaybackProperties(language: .custom(text: nil, audio: "custom"))
@@ -190,11 +191,11 @@ class LanguagePreferencesSpec: QuickSpec {
                         
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["playSessionId"] = "playSessionId"
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            callback(json.decode(PlaybackEntitlement.self), PlayBackEntitlementV2.requiedJson.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         let properties = PlaybackProperties(language: .defaultBehaviour)
@@ -233,11 +234,11 @@ class LanguagePreferencesSpec: QuickSpec {
                         
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["playSessionId"] = "playSessionId"
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            callback(json.decode(PlaybackEntitlement.self), PlayBackEntitlementV2.requiedJson.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         let properties = PlaybackProperties(language: .userLocale)
@@ -276,11 +277,11 @@ class LanguagePreferencesSpec: QuickSpec {
                         
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["playSessionId"] = "playSessionId"
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            callback(json.decode(PlaybackEntitlement.self), PlayBackEntitlementV2.requiedJson.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         let properties = PlaybackProperties(language: .custom(text: custom, audio: nil))

--- a/ExposurePlaybackTests/PlayBackEntitlementV2+Extensions.swift
+++ b/ExposurePlaybackTests/PlayBackEntitlementV2+Extensions.swift
@@ -1,0 +1,117 @@
+//
+//  PlayBackEntitlementV2+Extensions.swift
+//  ExposurePlayback
+//
+//  Created by Udaya Sri Senarathne on 2019-04-15.
+//  Copyright © 2019 emp. All rights reserved.
+//
+
+import Foundation
+import Exposure
+
+extension PlayBackEntitlementV2 {
+    static var validJson: [String: Any] {
+        
+        let formats: [String: Any] = [
+            "format": "HLS",
+            "drm" : [
+                "com.apple.fps" : [
+                    "licenseServerUrl" : "licenseServerUrl",
+                    "certificateUrl" : "certificateUrl"
+                ]
+            ],
+        "mediaLocator": "https://cache-dev.cdn.ebsd.ericsson.net/L23/000079/000079_enigma.isml/live.mpd?t=2019-04-15T12%3A00%3A00.000"
+        ]
+        
+        let streamInfo: [String: Any] = [
+            "live" : false,
+            "static" : true,
+            "event" : false,
+            "start" : 1555329600,
+            "channelId" : "channelId",
+            "programId" : "programId"
+        ]
+        
+        let bookmarks: [String : Any] = [
+            "liveTime" : 10,
+            "lastViewedOffset" : 10,
+            "lastViewedTime" : 10
+        ]
+        
+        let contractRestrictions: [String: Any] = [
+            "airplayEnabled" : true,
+            "ffEnabled" : true,
+            "maxBitrate" : 20,
+            "maxResHeight" : 30,
+            "minBitrate": 10,
+            "rwEnabled": true,
+            "timeshiftEnabled" : true
+        ]
+        
+        
+        let json:[String: Any] = [
+            "productId":"productId",
+            "publicationId":"publicationId",
+            "playSessionId":"playSessionId",
+            "playToken":"playToken",
+            "playTokenExpiration": 10,
+            "formats":[formats],
+            "streamInfo":streamInfo,
+            "bookmarks":bookmarks,
+            "requestId":"requestId",
+            "contractRestrictions" : contractRestrictions
+        ]
+        
+        return json
+    }
+    
+    static var requiedJson: [String: Any] {
+        
+        let formats: [String: Any] = [
+            "format": "HLS",
+            "drm" : [
+                "com.apple.fps" : [
+                    "licenseServerUrl" : "licenseServerUrl",
+                    "certificateUrl" : "certificateUrl"
+                ]
+            ],
+            "mediaLocator": "https://cache-dev.cdn.ebsd.ericsson.net/L23/000079/000079_enigma.isml/live.mpd?t=2019-04-15T12%3A00%3A00.000"
+        ]
+        
+        let streamInfo: [String: Any] = [
+            "live" : false,
+            "static" : true,
+            "event" : false,
+            "start" : 0,
+            "channelId" : "channelId",
+            "programId" : "programId"
+        ]
+        
+        let bookmarks: [String : Any] = [
+            "liveTime" : 10,
+            "lastViewedOffset" : 10,
+            "lastViewedTime" : 10
+        ]
+        
+        let contractRestrictions: [String: Any] = [
+            "airplayEnabled" : true,
+            "ffEnabled" : true,
+            "maxBitrate" : 20,
+            "maxResHeight" : 30,
+            "minBitrate": 10,
+            "rwEnabled": true,
+            "timeshiftEnabled" : true
+        ]
+        
+        return [
+            "formats":[formats],
+            "playSessionId":"playSessionId",
+            "playToken": "playToken",
+            "playTokenExpiration" : 10,
+            "streamInfo" : streamInfo,
+            "productId": "productId",
+            "bookmarks":bookmarks,
+            "contractRestrictions": contractRestrictions,
+        ]
+    }
+}

--- a/ExposurePlaybackTests/Playable/AssetPlayableSpec.swift
+++ b/ExposurePlaybackTests/Playable/AssetPlayableSpec.swift
@@ -14,10 +14,19 @@ import Foundation
 @testable import ExposurePlayback
 
 internal class MockedAssetEntitlementProvider: AssetEntitlementProvider {
-    var mockedRequestEntitlement: (String, SessionToken, Environment, (PlaybackEntitlement?, ExposureError?, HTTPURLResponse?) -> Void) -> Void = { _,_,_,_ in }
     func requestEntitlement(assetId: String, using sessionToken: SessionToken, in environment: Environment, callback: @escaping (PlaybackEntitlement?, ExposureError?, HTTPURLResponse?) -> Void) {
-        mockedRequestEntitlement(assetId, sessionToken, environment, callback)
     }
+    
+    
+    var mockedRequestEntitlement: (String, SessionToken, Environment, (PlaybackEntitlement?, ExposureError?, HTTPURLResponse?) -> Void) -> Void = { _,_,_,_ in }
+    
+    var mockedRequestEntitlementV2: (String, SessionToken, Environment, (PlaybackEntitlement?, PlayBackEntitlementV2?, ExposureError?, HTTPURLResponse?) -> Void) -> Void = { _,_,_,_ in }
+    
+    func requestEntitlementV2(assetId: String, using sessionToken: SessionToken, in environment: Environment, callback: @escaping (PlaybackEntitlement?, PlayBackEntitlementV2?, ExposureError?, HTTPURLResponse?) -> Void) {
+  
+        mockedRequestEntitlementV2(assetId, sessionToken, environment, callback)
+    }
+
 }
 
 
@@ -32,18 +41,26 @@ class AssetPlayableSpec: QuickSpec {
         
         let environment = Environment(baseUrl: "http://mocked.example.com", customer: "Customer", businessUnit: "BusinessUnit")
         let sessionToken = SessionToken(value: "token")
-        
         describe("AssetPlayble") {
             
             it("Should prepare source with valid entitlement response") {
                 let provider = MockedAssetEntitlementProvider()
-                provider.mockedRequestEntitlement = { _,_,_, callback in
-                    guard let result = PlaybackEntitlement.validJson.decode(PlaybackEntitlement.self) else {
-                        callback(nil,ExposureError.generalError(error: MockedError.generalError), nil)
+                provider.mockedRequestEntitlementV2 = { _,_,_, callback in
+                    // EntitlementV2
+                    guard let entitlementV2 = PlayBackEntitlementV2.validJson.decode(PlayBackEntitlementV2.self) else {
+                        callback(nil, nil,ExposureError.generalError(error: MockedError.generalError), nil)
                         return
                     }
-                    callback(result,nil, nil)
+                    
+                    // ENtitlement V1
+                    guard let entitlementV1 = PlaybackEntitlement.validJson.decode(PlaybackEntitlement.self) else {
+                        callback(nil,nil,ExposureError.generalError(error: MockedError.generalError), nil)
+                        return
+                    }
+                    callback(entitlementV1, entitlementV2, nil, nil)
                 }
+                
+                
                 let playable = AssetPlayable(assetId: "channelId", entitlementProvider: provider)
                 var source: ExposureSource? = nil
                 var error: ExposureError? = nil
@@ -58,10 +75,10 @@ class AssetPlayableSpec: QuickSpec {
             
             it("Should fail to prepare source when encountering error") {
                 let provider = MockedAssetEntitlementProvider()
-                provider.mockedRequestEntitlement = { _,_,_, callback in
-                    callback(nil,ExposureError.generalError(error: MockedError.generalError), nil)
+                provider.mockedRequestEntitlementV2 = { _,_,_, callback in
+                    callback(nil,nil,ExposureError.generalError(error: MockedError.generalError), nil)
                 }
-                let playable = AssetPlayable(assetId: "channelId", entitlementProvider: provider)
+                let playable = AssetPlayable(assetId: "assetId", entitlementProvider: provider)
                 var source: ExposureSource? = nil
                 var error: ExposureError? = nil
                 playable.prepareSource(environment: environment, sessionToken: sessionToken) { src, err in

--- a/ExposurePlaybackTests/Playable/ChannelPlayableSpec.swift
+++ b/ExposurePlaybackTests/Playable/ChannelPlayableSpec.swift
@@ -14,7 +14,16 @@ import Foundation
 @testable import ExposurePlayback
 
 internal class MockedChannelEntitlementProvider: ChannelEntitlementProvider {
+    
+    func requestEntitlementV2(channelId: String, using sessionToken: SessionToken, in environment: Environment, callback: @escaping (PlaybackEntitlement?, PlayBackEntitlementV2?, ExposureError?, HTTPURLResponse?) -> Void) {
+        mockedRequestEntitlementV2(channelId, sessionToken, environment, callback)
+    }
+
     var mockedRequestEntitlement: (String, SessionToken, Environment, (PlaybackEntitlement?, ExposureError?, HTTPURLResponse?) -> Void) -> Void = { _,_,_,_ in }
+    
+    var mockedRequestEntitlementV2: (String, SessionToken, Environment, (PlaybackEntitlement?, PlayBackEntitlementV2?, ExposureError?, HTTPURLResponse?) -> Void) -> Void = { _,_,_,_ in }
+    
+    
     func requestEntitlement(channelId: String, using sessionToken: SessionToken, in environment: Environment, callback: @escaping (PlaybackEntitlement?, ExposureError?, HTTPURLResponse?) -> Void) {
         mockedRequestEntitlement(channelId, sessionToken, environment, callback)
     }
@@ -44,6 +53,22 @@ class ChannelPlayableSpec: QuickSpec {
                     }
                     callback(result,nil,nil)
                 }
+                
+                provider.mockedRequestEntitlementV2 = { _,_,_, callback in
+                    // EntitlementV2
+                    guard let entitlementV2 = PlayBackEntitlementV2.validJson.decode(PlayBackEntitlementV2.self) else {
+                        callback(nil, nil,ExposureError.generalError(error: MockedError.generalError), nil)
+                        return
+                    }
+                    
+                    // ENtitlement V1
+                    guard let entitlementV1 = PlaybackEntitlement.validJson.decode(PlaybackEntitlement.self) else {
+                        callback(nil,nil,ExposureError.generalError(error: MockedError.generalError), nil)
+                        return
+                    }
+                    callback(entitlementV1, entitlementV2, nil, nil)
+                }
+                
                 let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
                 var source: ExposureSource? = nil
                 var error: ExposureError? = nil
@@ -58,8 +83,8 @@ class ChannelPlayableSpec: QuickSpec {
             
             it("Should fail to prepare source when encountering error") {
                 let provider = MockedChannelEntitlementProvider()
-                provider.mockedRequestEntitlement = { _,_,_, callback in
-                    callback(nil,ExposureError.generalError(error: MockedError.generalError),nil)
+                provider.mockedRequestEntitlementV2 = { _,_,_, callback in
+                    callback(nil,nil,ExposureError.generalError(error: MockedError.generalError),nil)
                 }
                 let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
                 var source: ExposureSource? = nil

--- a/ExposurePlaybackTests/PlaybackEntitlement+Extensions.swift
+++ b/ExposurePlaybackTests/PlaybackEntitlement+Extensions.swift
@@ -14,7 +14,8 @@ extension PlaybackEntitlement {
         let fairplayJson:[String: Any] = [
             "secondaryMediaLocator":"secondaryMediaLocator",
             "certificateUrl":"certificateUrl",
-            "licenseAcquisitionUrl":"licenseAcquisitionUrl"
+            "licenseAcquisitionUrl":"licenseAcquisitionUrl",
+            "licenseServerUrl": "licenseServerUrl"
         ]
         let json:[String: Any] = [
             "playToken":"playToken",

--- a/ExposurePlaybackTests/SeekToLive/ChannelSource+SeekToLive.swift
+++ b/ExposurePlaybackTests/SeekToLive/ChannelSource+SeekToLive.swift
@@ -33,14 +33,29 @@ class ChannelSourceSeekToLiveSpec: QuickSpec {
                 it("should allow playback") {
                     // Configure the playable
                     let provider = MockedChannelEntitlementProvider()
-                    provider.mockedRequestEntitlement = { _,_,_, callback in
+                    provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                         var json = PlaybackEntitlement.requiedJson
                         json["mediaLocator"] = "file://play/.isml"
                         json["playSessionId"] = "SeekToLiveTrigger"
                         json["ffEnabled"] = false
                         json["rwEnabled"] = false
                         json["timeshiftEnabled"] = false
-                        callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                        
+                        let contractRestrictions: [String: Any] = [
+                            "airplayEnabled" : true,
+                            "ffEnabled" : false,
+                            "maxBitrate" : 20,
+                            "maxResHeight" : 30,
+                            "minBitrate": 10,
+                            "rwEnabled": false,
+                            "timeshiftEnabled" : false
+                        ]
+                        
+                        var entitlementJson2 = PlayBackEntitlementV2.requiedJson
+                        entitlementJson2["playSessionId"] = "SeekToLiveTrigger"
+                        entitlementJson2["contractRestrictions"] = contractRestrictions
+                        
+                        callback(json.decode(PlaybackEntitlement.self), entitlementJson2.decode(PlayBackEntitlementV2.self), nil, nil)
                     }
                     let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
                     let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -55,18 +70,32 @@ class ChannelSourceSeekToLiveSpec: QuickSpec {
             // MARK: + Error fetching EPG
             context("Error fetching EPG") {
                 it("should allow seek to live with warning message") {
-                    
-
+                
                     // Configure the playable
                     let provider = MockedChannelEntitlementProvider()
-                    provider.mockedRequestEntitlement = { _,_,_, callback in
+                    provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                         var json = PlaybackEntitlement.requiedJson
                         json["mediaLocator"] = "file://play/.isml"
                         json["playSessionId"] = "SeekToLiveTrigger"
                         json["ffEnabled"] = false
                         json["rwEnabled"] = false
                         json["timeshiftEnabled"] = false
-                        callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                        
+                        let contractRestrictions: [String: Any] = [
+                            "airplayEnabled" : true,
+                            "ffEnabled" : false,
+                            "maxBitrate" : 20,
+                            "maxResHeight" : 30,
+                            "minBitrate": 10,
+                            "rwEnabled": false,
+                            "timeshiftEnabled" : false
+                        ]
+                        
+                        var entitlementJson2 = PlayBackEntitlementV2.requiedJson
+                        entitlementJson2["playSessionId"] = "SeekToLiveTrigger"
+                        entitlementJson2["contractRestrictions"] = contractRestrictions
+                        
+                        callback(json.decode(PlaybackEntitlement.self), entitlementJson2.decode(PlayBackEntitlementV2.self), nil, nil)
                     }
                     let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
                     let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -89,13 +118,28 @@ class ChannelSourceSeekToLiveSpec: QuickSpec {
                 it("should allow seek to live with warning message") {
                     // Configure the playable
                     let provider = MockedChannelEntitlementProvider()
-                    provider.mockedRequestEntitlement = { _,_,_, callback in
+                    provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                         var json = PlaybackEntitlement.requiedJson
                         json["mediaLocator"] = "file://play/.isml"
                         json["ffEnabled"] = false
                         json["rwEnabled"] = false
                         json["timeshiftEnabled"] = false
-                        callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                        
+                        
+                        let contractRestrictions: [String: Any] = [
+                            "airplayEnabled" : true,
+                            "ffEnabled" : false,
+                            "maxBitrate" : 20,
+                            "maxResHeight" : 30,
+                            "minBitrate": 10,
+                            "rwEnabled": false,
+                            "timeshiftEnabled" : false
+                        ]
+                        
+                        var entitlementJson2 = PlayBackEntitlementV2.requiedJson
+                        entitlementJson2["contractRestrictions"] = contractRestrictions
+                        
+                        callback(json.decode(PlaybackEntitlement.self), entitlementJson2.decode(PlayBackEntitlementV2.self), nil, nil)
                     }
                     let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
                     let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -113,14 +157,29 @@ class ChannelSourceSeekToLiveSpec: QuickSpec {
                 it("should allow seek to live if encountering epg gap") {
                     // Configure the playable
                     let provider = MockedChannelEntitlementProvider()
-                    provider.mockedRequestEntitlement = { _,_,_, callback in
+                    provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                         var json = PlaybackEntitlement.requiedJson
                         json["mediaLocator"] = "file://play/.isml"
                         json["playSessionId"] = "SeekToLiveTrigger"
                         json["ffEnabled"] = false
                         json["rwEnabled"] = false
                         json["timeshiftEnabled"] = false
-                        callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                        
+                        let contractRestrictions: [String: Any] = [
+                            "airplayEnabled" : true,
+                            "ffEnabled" : false,
+                            "maxBitrate" : 20,
+                            "maxResHeight" : 30,
+                            "minBitrate": 10,
+                            "rwEnabled": false,
+                            "timeshiftEnabled" : false
+                        ]
+                        
+                        var entitlementJson2 = PlayBackEntitlementV2.requiedJson
+                        entitlementJson2["playSessionId"] = "SeekToLiveTrigger"
+                        entitlementJson2["contractRestrictions"] = contractRestrictions
+                        
+                        callback(json.decode(PlaybackEntitlement.self), entitlementJson2.decode(PlayBackEntitlementV2.self), nil, nil)
                     }
                     let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
                     let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -136,18 +195,31 @@ class ChannelSourceSeekToLiveSpec: QuickSpec {
             // MARK: + NOT_ENTITLED
             context("NOT_ENTITLED") {
                 it("should stop with error if not entitled") {
-                    
-
                     // Configure the playable
                     let provider = MockedChannelEntitlementProvider()
-                    provider.mockedRequestEntitlement = { _,_,_, callback in
+                    provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                         var json = PlaybackEntitlement.requiedJson
                         json["mediaLocator"] = "file://play/.isml"
                         json["playSessionId"] = "SeekToLiveTrigger"
                         json["ffEnabled"] = false
                         json["rwEnabled"] = false
                         json["timeshiftEnabled"] = false
-                        callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                        
+                        let contractRestrictions: [String: Any] = [
+                            "airplayEnabled" : true,
+                            "ffEnabled" : false,
+                            "maxBitrate" : 20,
+                            "maxResHeight" : 30,
+                            "minBitrate": 10,
+                            "rwEnabled": false,
+                            "timeshiftEnabled" : false
+                        ]
+                        
+                        var entitlementJson2 = PlayBackEntitlementV2.requiedJson
+                        entitlementJson2["playSessionId"] = "SeekToLiveTrigger"
+                        entitlementJson2["contractRestrictions"] = contractRestrictions
+                        
+                        callback(json.decode(PlaybackEntitlement.self), entitlementJson2.decode(PlayBackEntitlementV2.self), nil, nil)
                     }
                     let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
                     let properties = PlaybackProperties(playFrom: .defaultBehaviour)

--- a/ExposurePlaybackTests/SeekToLive/ProgramSource+DynamicManifest+SeekToLive.swift
+++ b/ExposurePlaybackTests/SeekToLive/ProgramSource+DynamicManifest+SeekToLive.swift
@@ -33,14 +33,29 @@ class DynamicProgramSourceSeekToLiveSpec: QuickSpec {
                 it("should allow playback") {
                     // Configure the playable
                     let provider = MockedProgramEntitlementProvider()
-                    provider.mockedRequestEntitlement = { _,_,_, callback in
+                    provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                         var json = PlaybackEntitlement.requiedJson
                         json["mediaLocator"] = "file://play/.isml"
                         json["playSessionId"] = "SeekToLiveTrigger"
                         json["ffEnabled"] = false
                         json["rwEnabled"] = false
                         json["timeshiftEnabled"] = false
-                        callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                        
+                        let contractRestrictions: [String: Any] = [
+                            "airplayEnabled" : true,
+                            "ffEnabled" : false,
+                            "maxBitrate" : 20,
+                            "maxResHeight" : 30,
+                            "minBitrate": 10,
+                            "rwEnabled": false,
+                            "timeshiftEnabled" : false
+                        ]
+                        
+                        var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                        entitlementVersion2Json["playSessionId"] = "SeekToLiveTrigger"
+                        entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                        
+                        callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                     }
                     let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                     let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -57,14 +72,29 @@ class DynamicProgramSourceSeekToLiveSpec: QuickSpec {
                 it("should allow seek to live with warning message") {
                     // Configure the playable
                     let provider = MockedProgramEntitlementProvider()
-                    provider.mockedRequestEntitlement = { _,_,_, callback in
+                    provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                         var json = PlaybackEntitlement.requiedJson
                         json["mediaLocator"] = "file://play/.isml"
                         json["playSessionId"] = "SeekToLiveTrigger"
                         json["ffEnabled"] = false
                         json["rwEnabled"] = false
                         json["timeshiftEnabled"] = false
-                        callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                        
+                        let contractRestrictions: [String: Any] = [
+                            "airplayEnabled" : true,
+                            "ffEnabled" : false,
+                            "maxBitrate" : 20,
+                            "maxResHeight" : 30,
+                            "minBitrate": 10,
+                            "rwEnabled": false,
+                            "timeshiftEnabled" : false
+                        ]
+                        
+                        var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                        entitlementVersion2Json["playSessionId"] = "SeekToLiveTrigger"
+                        entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                        
+                        callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                     }
                     let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                     let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -82,14 +112,29 @@ class DynamicProgramSourceSeekToLiveSpec: QuickSpec {
                 it("should allow seek to live with warning message") {
                     // Configure the playable
                     let provider = MockedProgramEntitlementProvider()
-                    provider.mockedRequestEntitlement = { _,_,_, callback in
+                    provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                         var json = PlaybackEntitlement.requiedJson
                         json["mediaLocator"] = "file://play/.isml"
                         json["playSessionId"] = "SeekToLiveTrigger"
                         json["ffEnabled"] = false
                         json["rwEnabled"] = false
                         json["timeshiftEnabled"] = false
-                        callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                        
+                        let contractRestrictions: [String: Any] = [
+                            "airplayEnabled" : true,
+                            "ffEnabled" : false,
+                            "maxBitrate" : 20,
+                            "maxResHeight" : 30,
+                            "minBitrate": 10,
+                            "rwEnabled": false,
+                            "timeshiftEnabled" : false
+                        ]
+                        
+                        var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                        entitlementVersion2Json["playSessionId"] = "SeekToLiveTrigger"
+                        entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                        
+                        callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                     }
                     let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                     let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -107,14 +152,28 @@ class DynamicProgramSourceSeekToLiveSpec: QuickSpec {
                 it("should allow seek to live if encountering epg gap") {
                     // Configure the playable
                     let provider = MockedProgramEntitlementProvider()
-                    provider.mockedRequestEntitlement = { _,_,_, callback in
+                    provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                         var json = PlaybackEntitlement.requiedJson
                         json["mediaLocator"] = "file://play/.isml"
                         json["playSessionId"] = "SeekToLiveTrigger"
                         json["ffEnabled"] = false
                         json["rwEnabled"] = false
                         json["timeshiftEnabled"] = false
-                        callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                        let contractRestrictions: [String: Any] = [
+                            "airplayEnabled" : true,
+                            "ffEnabled" : false,
+                            "maxBitrate" : 20,
+                            "maxResHeight" : 30,
+                            "minBitrate": 10,
+                            "rwEnabled": false,
+                            "timeshiftEnabled" : false
+                        ]
+                        
+                        var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                        entitlementVersion2Json["playSessionId"] = "SeekToLiveTrigger"
+                        entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                        
+                        callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                     }
                     let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                     let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -132,14 +191,28 @@ class DynamicProgramSourceSeekToLiveSpec: QuickSpec {
                 it("should stop with error if not entitled") {
                     // Configure the playable
                     let provider = MockedProgramEntitlementProvider()
-                    provider.mockedRequestEntitlement = { _,_,_, callback in
+                    provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                         var json = PlaybackEntitlement.requiedJson
                         json["mediaLocator"] = "file://play/.isml"
                         json["playSessionId"] = "SeekToLiveTrigger"
                         json["ffEnabled"] = false
                         json["rwEnabled"] = false
                         json["timeshiftEnabled"] = false
-                        callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                        let contractRestrictions: [String: Any] = [
+                            "airplayEnabled" : true,
+                            "ffEnabled" : false,
+                            "maxBitrate" : 20,
+                            "maxResHeight" : 30,
+                            "minBitrate": 10,
+                            "rwEnabled": false,
+                            "timeshiftEnabled" : false
+                        ]
+                        
+                        var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                        entitlementVersion2Json["playSessionId"] = "SeekToLiveTrigger"
+                        entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                        
+                        callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                     }
                     let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                     let properties = PlaybackProperties(playFrom: .defaultBehaviour)

--- a/ExposurePlaybackTests/SeekToLive/ProgramSource+StaticManifest+SeekToLive.swift
+++ b/ExposurePlaybackTests/SeekToLive/ProgramSource+StaticManifest+SeekToLive.swift
@@ -59,22 +59,37 @@ class StaticProgramSourceSeekToLiveSpec: QuickSpec {
                     // Mock the ChannelPlayable used in SeekToLive
                     env.mockSeekToLiveChannelPlayable{ channelId in
                         let provider = MockedChannelEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
-                            callback(nil, ExposureError.exposureResponse(reason: ExposureResponseMessage(httpCode: 404, message: "SOME_ERROR")), nil)
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
+                            callback(nil, nil, ExposureError.exposureResponse(reason: ExposureResponseMessage(httpCode: 404, message: "SOME_ERROR")), nil)
                         }
                         return ChannelPlayable(assetId: channelId, entitlementProvider: provider)
                     }
 
                     // Configure the playable
                     let provider = MockedProgramEntitlementProvider()
-                    provider.mockedRequestEntitlement = { _,_,_, callback in
+                    provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                         var json = PlaybackEntitlement.requiedJson
                         json["mediaLocator"] = "file://play/.isml"
                         json["playSessionId"] = "SeekToLiveTrigger"
                         json["ffEnabled"] = false
                         json["rwEnabled"] = false
                         json["timeshiftEnabled"] = false
-                        callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                        
+                        let contractRestrictions: [String: Any] = [
+                            "airplayEnabled" : true,
+                            "ffEnabled" : false,
+                            "maxBitrate" : 20,
+                            "maxResHeight" : 30,
+                            "minBitrate": 10,
+                            "rwEnabled": false,
+                            "timeshiftEnabled" : false
+                        ]
+                        
+                        var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                        entitlementVersion2Json["playSessionId"] = "SeekToLiveTrigger"
+                        entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                        
+                        callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                     }
                     let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                     let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -137,25 +152,46 @@ class StaticProgramSourceSeekToLiveSpec: QuickSpec {
                     // Mock the ChannelPlayable used in SeekToLive
                     env.mockSeekToLiveChannelPlayable{ channelId in
                         let provider = MockedChannelEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["playSessionId"] = "SeekToLiveFetchedEntitlement"
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["playSessionId"] = "SeekToLiveFetchedEntitlement"
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         return ChannelPlayable(assetId: channelId, entitlementProvider: provider)
                     }
 
                     // Configure the playable
                     let provider = MockedProgramEntitlementProvider()
-                    provider.mockedRequestEntitlement = { _,_,_, callback in
+                    provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                         var json = PlaybackEntitlement.requiedJson
                         json["mediaLocator"] = "file://play/.isml"
                         json["playSessionId"] = "SeekToLiveTrigger"
                         json["ffEnabled"] = false
                         json["rwEnabled"] = false
                         json["timeshiftEnabled"] = false
-                        callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                        
+                        
+                        let contractRestrictions: [String: Any] = [
+                            "airplayEnabled" : true,
+                            "ffEnabled" : false,
+                            "maxBitrate" : 20,
+                            "maxResHeight" : 30,
+                            "minBitrate": 10,
+                            "rwEnabled": false,
+                            "timeshiftEnabled" : false
+                        ]
+                        
+                        var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                        entitlementVersion2Json["playSessionId"] = "SeekToLiveTrigger"
+                        entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                        
+                        callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                     }
                     let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                     let properties = PlaybackProperties(playFrom: .defaultBehaviour)

--- a/ExposurePlaybackTests/SeekToTime/ChannelSource+SeekToTime.swift
+++ b/ExposurePlaybackTests/SeekToTime/ChannelSource+SeekToTime.swift
@@ -33,11 +33,20 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                     it("should allow seek") {
                         // Configure the playable
                         let provider = MockedChannelEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = true
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "ffEnabled" : true
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
+                            
                         }
                         let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
                         
@@ -62,11 +71,18 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                         it("should allow seek if entitled") {
                             // Configure the playable
                             let provider = MockedChannelEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                
+                                let contractRestrictions: [String: Any] = [
+                                    "ffEnabled" : true
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
 
@@ -86,11 +102,17 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                         it("should allow seek with warning message") {
                             // Configure the playable
                             let provider = MockedChannelEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                let contractRestrictions: [String: Any] = [
+                                    "ffEnabled" : true
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
                             
@@ -113,11 +135,17 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                         it("should allow seek with warning message") {
                             // Configure the playable
                             let provider = MockedChannelEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                let contractRestrictions: [String: Any] = [
+                                    "ffEnabled" : true
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
 
@@ -139,11 +167,17 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                         it("should allow seek if encountering epg gap") {
                             // Configure the playable
                             let provider = MockedChannelEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                let contractRestrictions: [String: Any] = [
+                                    "ffEnabled" : true
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
 
@@ -165,11 +199,17 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                         it("should stop with error if not entitled") {
                             // Configure the playable
                             let provider = MockedChannelEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                let contractRestrictions: [String: Any] = [
+                                    "ffEnabled" : true
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
 
@@ -198,11 +238,18 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                     it("should seek to live point") {
                         // Configure the playable
                         let provider = MockedChannelEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = true
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "ffEnabled" : true
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
 
@@ -235,11 +282,17 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                     it("should ignore seek and deliver warning") {
                         // Configure the playable
                         let provider = MockedChannelEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = true
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            let contractRestrictions: [String: Any] = [
+                                "ffEnabled" : true
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
 
@@ -272,11 +325,17 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                     it("should ignore seek with warning message") {
                         // Configure the playable
                         let provider = MockedChannelEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["rwEnabled"] = true
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            let contractRestrictions: [String: Any] = [
+                                "rwEnabled" : true
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
 
@@ -298,11 +357,18 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                     it("should ignore seek if encountering epg gap") {
                         // Configure the playable
                         let provider = MockedChannelEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["rwEnabled"] = true
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "rwEnabled" : true
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
 
@@ -326,11 +392,17 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                         it("should stop playback with error") {
                             // Configure the playable
                             let provider = MockedChannelEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["rwEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                let contractRestrictions: [String: Any] = [
+                                    "rwEnabled" : true
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
 
@@ -350,16 +422,31 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                         it("should allow playback") {
                             // Configure the playable
                             let provider = MockedChannelEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
                                 json["rwEnabled"] = true
                                 json["timeshiftEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
-                            }
-                            let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
 
+                                
+                                let contractRestrictions: [String: Any] = [
+                                    "airplayEnabled" : true,
+                                    "ffEnabled" : true,
+                                    "maxBitrate" : 20,
+                                    "maxResHeight" : 30,
+                                    "minBitrate": 10,
+                                    "rwEnabled": true,
+                                    "timeshiftEnabled" : true
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
+                                
+                            }
+                            
+                            let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
 
                             // Initiate test
                             let currentDate = Date().unixEpoch
@@ -380,13 +467,24 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                 context("Enforce FastForward") {
                     it("should restrict seeking forward") {
                         let provider = MockedChannelEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = false
                             json["rwEnabled"] = false
                             json["timeshiftEnabled"] = false
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "ffEnabled" : false,
+                                "rwEnabled": false,
+                                "timeshiftEnabled" : false
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["playSessionId"] = "SeekToLiveTrigger"
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
                         
@@ -406,13 +504,23 @@ class ChannelSourceSeekToTimeSpec: QuickSpec {
                 context("Enforce Rewind") {
                     it("should restrict seeking back") {
                         let provider = MockedChannelEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = false
                             json["rwEnabled"] = false
                             json["timeshiftEnabled"] = false
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            let contractRestrictions: [String: Any] = [
+                                "ffEnabled" : false,
+                                "rwEnabled": false,
+                                "timeshiftEnabled" : false
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["playSessionId"] = "SeekToLiveTrigger"
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ChannelPlayable(assetId: "channelId", entitlementProvider: provider)
                         

--- a/ExposurePlaybackTests/SeekToTime/ProgramSource+DynamicManifest+SeekToTime.swift
+++ b/ExposurePlaybackTests/SeekToTime/ProgramSource+DynamicManifest+SeekToTime.swift
@@ -39,11 +39,25 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                     it("should allow seek") {
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = true
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "airplayEnabled" : true,
+                                "ffEnabled" : true,
+                                "maxBitrate" : 20,
+                                "maxResHeight" : 30,
+                                "minBitrate": 10,
+                                "rwEnabled": false,
+                                "timeshiftEnabled" : false
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         
@@ -69,11 +83,25 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                         it("should allow seek if entitled") {
                             // Configure the playable
                             let provider = MockedProgramEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                
+                                let contractRestrictions: [String: Any] = [
+                                    "airplayEnabled" : true,
+                                    "ffEnabled" : true,
+                                    "maxBitrate" : 20,
+                                    "maxResHeight" : 30,
+                                    "minBitrate": 10,
+                                    "rwEnabled": false,
+                                    "timeshiftEnabled" : false
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                             
@@ -93,11 +121,25 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                         it("should allow seek with warning message") {
                             // Configure the playable
                             let provider = MockedProgramEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                
+                                let contractRestrictions: [String: Any] = [
+                                    "airplayEnabled" : true,
+                                    "ffEnabled" : true,
+                                    "maxBitrate" : 20,
+                                    "maxResHeight" : 30,
+                                    "minBitrate": 10,
+                                    "rwEnabled": false,
+                                    "timeshiftEnabled" : false
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                             
@@ -120,11 +162,25 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                         it("should allow seek with warning message") {
                             // Configure the playable
                             let provider = MockedProgramEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                
+                                let contractRestrictions: [String: Any] = [
+                                    "airplayEnabled" : true,
+                                    "ffEnabled" : true,
+                                    "maxBitrate" : 20,
+                                    "maxResHeight" : 30,
+                                    "minBitrate": 10,
+                                    "rwEnabled": false,
+                                    "timeshiftEnabled" : false
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                             
@@ -146,11 +202,25 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                         it("should allow seek if encountering epg gap") {
                             // Configure the playable
                             let provider = MockedProgramEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                
+                                let contractRestrictions: [String: Any] = [
+                                    "airplayEnabled" : true,
+                                    "ffEnabled" : true,
+                                    "maxBitrate" : 20,
+                                    "maxResHeight" : 30,
+                                    "minBitrate": 10,
+                                    "rwEnabled": false,
+                                    "timeshiftEnabled" : false
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                             
@@ -172,11 +242,25 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                         it("should stop with error if not entitled") {
                             // Configure the playable
                             let provider = MockedProgramEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                
+                                let contractRestrictions: [String: Any] = [
+                                    "airplayEnabled" : true,
+                                    "ffEnabled" : true,
+                                    "maxBitrate" : 20,
+                                    "maxResHeight" : 30,
+                                    "minBitrate": 10,
+                                    "rwEnabled": false,
+                                    "timeshiftEnabled" : false
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                             
@@ -205,11 +289,25 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                     it("should seek to live point") {
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = true
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "airplayEnabled" : true,
+                                "ffEnabled" : true,
+                                "maxBitrate" : 20,
+                                "maxResHeight" : 30,
+                                "minBitrate": 10,
+                                "rwEnabled": false,
+                                "timeshiftEnabled" : false
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         
@@ -234,11 +332,25 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                     it("should ignore seek and deliver warning") {
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = true
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "airplayEnabled" : true,
+                                "ffEnabled" : true,
+                                "maxBitrate" : 20,
+                                "maxResHeight" : 30,
+                                "minBitrate": 10,
+                                "rwEnabled": false,
+                                "timeshiftEnabled" : false
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
 
@@ -271,11 +383,25 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                     it("should ignore seek with warning message") {
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["rwEnabled"] = true
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "airplayEnabled" : true,
+                                "ffEnabled" : false,
+                                "maxBitrate" : 20,
+                                "maxResHeight" : 30,
+                                "minBitrate": 10,
+                                "rwEnabled": true,
+                                "timeshiftEnabled" : false
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         
@@ -297,11 +423,25 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                     it("should ignore seek if encountering epg gap") {
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["rwEnabled"] = true
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "airplayEnabled" : true,
+                                "ffEnabled" : false,
+                                "maxBitrate" : 20,
+                                "maxResHeight" : 30,
+                                "minBitrate": 10,
+                                "rwEnabled": true,
+                                "timeshiftEnabled" : false
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         
@@ -325,11 +465,25 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                         it("should stop playback with error") {
                             // Configure the playable
                             let provider = MockedProgramEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["rwEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                
+                                let contractRestrictions: [String: Any] = [
+                                    "airplayEnabled" : true,
+                                    "ffEnabled" : false,
+                                    "maxBitrate" : 20,
+                                    "maxResHeight" : 30,
+                                    "minBitrate": 10,
+                                    "rwEnabled": true,
+                                    "timeshiftEnabled" : false
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                             
@@ -349,13 +503,27 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                         it("should allow playback") {
                             // Configure the playable
                             let provider = MockedProgramEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
                                 json["rwEnabled"] = true
                                 json["timeshiftEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                
+                                let contractRestrictions: [String: Any] = [
+                                    "airplayEnabled" : true,
+                                    "ffEnabled" : true,
+                                    "maxBitrate" : 20,
+                                    "maxResHeight" : 30,
+                                    "minBitrate": 10,
+                                    "rwEnabled": true,
+                                    "timeshiftEnabled" : true
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                             
@@ -378,13 +546,27 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                 context("Enforce FastForward") {
                     it("should restrict seeking forward") {
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = false
                             json["rwEnabled"] = false
                             json["timeshiftEnabled"] = false
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "airplayEnabled" : true,
+                                "ffEnabled" : false,
+                                "maxBitrate" : 20,
+                                "maxResHeight" : 30,
+                                "minBitrate": 10,
+                                "rwEnabled": false,
+                                "timeshiftEnabled" : false
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         
@@ -403,13 +585,26 @@ class DynamicProgramSourceSeekToTimeSpec: QuickSpec {
                 context("Enforce Rewind") {
                     it("should restrict seeking back") {
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = false
                             json["rwEnabled"] = false
                             json["timeshiftEnabled"] = false
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "airplayEnabled" : true,
+                                "ffEnabled" : false,
+                                "maxBitrate" : 20,
+                                "maxResHeight" : 30,
+                                "minBitrate": 10,
+                                "rwEnabled": false,
+                                "timeshiftEnabled" : false
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         

--- a/ExposurePlaybackTests/SeekToTime/ProgramSource+StaticManifest+SeekToTime.swift
+++ b/ExposurePlaybackTests/SeekToTime/ProgramSource+StaticManifest+SeekToTime.swift
@@ -65,11 +65,25 @@ class StaticProgramSourceSeekToTimeSpec: QuickSpec {
 
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = true
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "airplayEnabled" : true,
+                                "ffEnabled" : true,
+                                "maxBitrate" : 20,
+                                "maxResHeight" : 30,
+                                "minBitrate": 10,
+                                "rwEnabled": false,
+                                "timeshiftEnabled" : false
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -129,11 +143,25 @@ class StaticProgramSourceSeekToTimeSpec: QuickSpec {
 
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = true
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "airplayEnabled" : true,
+                                "ffEnabled" : true,
+                                "maxBitrate" : 20,
+                                "maxResHeight" : 30,
+                                "minBitrate": 10,
+                                "rwEnabled": false,
+                                "timeshiftEnabled" : false
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -200,19 +228,33 @@ class StaticProgramSourceSeekToTimeSpec: QuickSpec {
                             // Mock the ProgramService playable generator
                             env.mockProgramServicePlayable{ program in
                                 let provider = MockedProgramEntitlementProvider()
-                                provider.mockedRequestEntitlement = { _,_,_, callback in
-                                    callback(nil, ExposureError.exposureResponse(reason: ExposureResponseMessage(httpCode: 404, message: "SOME_ERROR")), nil)
+                                provider.mockedRequestEntitlementV2 = { _,_,_, callback in
+                                    callback(nil, nil, ExposureError.exposureResponse(reason: ExposureResponseMessage(httpCode: 404, message: "SOME_ERROR")), nil)
                                 }
                                 return ProgramPlayable(assetId: program.programId, channelId: program.channelId, entitlementProvider: provider)
                             }
 
                             // Configure the playable
                             let provider = MockedProgramEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                
+                                let contractRestrictions: [String: Any] = [
+                                    "airplayEnabled" : true,
+                                    "ffEnabled" : true,
+                                    "maxBitrate" : 20,
+                                    "maxResHeight" : 30,
+                                    "minBitrate": 10,
+                                    "rwEnabled": false,
+                                    "timeshiftEnabled" : false
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                             let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -274,27 +316,55 @@ class StaticProgramSourceSeekToTimeSpec: QuickSpec {
                             // Mock the ProgramService playable generator
                             env.mockProgramServicePlayable{ program in
                                 let provider = MockedProgramEntitlementProvider()
-                                provider.mockedRequestEntitlement = { _,_,_, callback in
+                                provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                     var json = PlaybackEntitlement.requiedJson
                                     json["mediaLocator"] = "file://play/.isml"
                                     json["playToken"] = "ProgramSevicedFetchedEntitlement"
                                     json["ffEnabled"] = false
                                     json["rwEnabled"] = false
                                     json["timeshiftEnabled"] = false
-                                    callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                    
+                                    let contractRestrictions: [String: Any] = [
+                                        "airplayEnabled" : true,
+                                        "ffEnabled" : false,
+                                        "maxBitrate" : 20,
+                                        "maxResHeight" : 30,
+                                        "minBitrate": 10,
+                                        "rwEnabled": false,
+                                        "timeshiftEnabled" : false
+                                    ]
+                                    
+                                    var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                    entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                    
+                                    callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                                 }
                                 return ProgramPlayable(assetId: program.programId, channelId: program.channelId, entitlementProvider: provider)
                             }
                             
                             // Configure the playable
                             let provider = MockedProgramEntitlementProvider()
-                            provider.mockedRequestEntitlement = { _,_,_, callback in
+                            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                                 var json = PlaybackEntitlement.requiedJson
                                 json["mediaLocator"] = "file://play/.isml"
                                 json["ffEnabled"] = true
                                 json["rwEnabled"] = true
                                 json["timeshiftEnabled"] = true
-                                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                                
+                                let contractRestrictions: [String: Any] = [
+                                    "airplayEnabled" : true,
+                                    "ffEnabled" : true,
+                                    "maxBitrate" : 20,
+                                    "maxResHeight" : 30,
+                                    "minBitrate": 10,
+                                    "rwEnabled": true,
+                                    "timeshiftEnabled" : true
+                                ]
+                                
+                                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                                
+                                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                             }
                             let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                             let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -350,13 +420,27 @@ class StaticProgramSourceSeekToTimeSpec: QuickSpec {
 
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = false
                             json["rwEnabled"] = false
                             json["timeshiftEnabled"] = false
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "airplayEnabled" : true,
+                                "ffEnabled" : false,
+                                "maxBitrate" : 20,
+                                "maxResHeight" : 30,
+                                "minBitrate": 10,
+                                "rwEnabled": false,
+                                "timeshiftEnabled" : false
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         let properties = PlaybackProperties(playFrom: .defaultBehaviour)
@@ -410,13 +494,27 @@ class StaticProgramSourceSeekToTimeSpec: QuickSpec {
 
                         // Configure the playable
                         let provider = MockedProgramEntitlementProvider()
-                        provider.mockedRequestEntitlement = { _,_,_, callback in
+                        provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                             var json = PlaybackEntitlement.requiedJson
                             json["mediaLocator"] = "file://play/.isml"
                             json["ffEnabled"] = false
                             json["rwEnabled"] = false
                             json["timeshiftEnabled"] = false
-                            callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                            
+                            let contractRestrictions: [String: Any] = [
+                                "airplayEnabled" : true,
+                                "ffEnabled" : false,
+                                "maxBitrate" : 20,
+                                "maxResHeight" : 30,
+                                "minBitrate": 10,
+                                "rwEnabled": false,
+                                "timeshiftEnabled" : false
+                            ]
+                            
+                            var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                            entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                            
+                            callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                         }
                         let playable = ProgramPlayable(assetId: "program1", channelId: "channelId", entitlementProvider: provider)
                         let properties = PlaybackProperties(playFrom: .defaultBehaviour)

--- a/ExposurePlaybackTests/SeekToTimeMock.swift
+++ b/ExposurePlaybackTests/SeekToTimeMock.swift
@@ -507,8 +507,8 @@ class SeekToTimeMock {
         // Mock the ProgramService playable generator
         env.mockProgramServicePlayable{ program in
             let provider = MockedProgramEntitlementProvider()
-            provider.mockedRequestEntitlement = { _,_,_, callback in
-                callback(nil, ExposureError.exposureResponse(reason: ExposureResponseMessage(httpCode: 404, message: "SOME_ERROR")), nil)
+            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
+                callback(nil, nil, ExposureError.exposureResponse(reason: ExposureResponseMessage(httpCode: 404, message: "SOME_ERROR")), nil)
             }
             return ProgramPlayable(assetId: program.programId, channelId: program.channelId, entitlementProvider: provider)
         }
@@ -569,14 +569,28 @@ class SeekToTimeMock {
         // Mock the ProgramService playable generator
         env.mockProgramServicePlayable{ program in
             let provider = MockedProgramEntitlementProvider()
-            provider.mockedRequestEntitlement = { _,_,_, callback in
+            provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                 var json = PlaybackEntitlement.requiedJson
                 json["mediaLocator"] = "file://play/.isml"
                 json["playToken"] = "ProgramSevicedFetchedEntitlement"
                 json["ffEnabled"] = false
                 json["rwEnabled"] = false
                 json["timeshiftEnabled"] = false
-                callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                
+                let contractRestrictions: [String: Any] = [
+                    "airplayEnabled" : true,
+                    "ffEnabled" : false,
+                    "maxBitrate" : 20,
+                    "maxResHeight" : 30,
+                    "minBitrate": 10,
+                    "rwEnabled": false,
+                    "timeshiftEnabled" : false
+                ]
+                
+                var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                entitlementVersion2Json["contractRestrictions"] = contractRestrictions
+                
+                callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
             }
             return ProgramPlayable(assetId: program.programId, channelId: program.channelId, entitlementProvider: provider)
         }

--- a/ExposurePlaybackTests/StartTime/AssetSourceSpec+StartTime.swift
+++ b/ExposurePlaybackTests/StartTime/AssetSourceSpec+StartTime.swift
@@ -34,17 +34,31 @@ class AssetSourceStartTimeSpec: QuickSpec {
             func generatePlayable(pipe: String = "file://play/.isml", lastViewedOffset: Int? = nil, lastViewedTime: Int? = nil) -> AssetPlayable {
                 // Configure the playable
                 let provider = MockedAssetEntitlementProvider()
-                provider.mockedRequestEntitlement = { _,_,_, callback in
+                
+                provider.mockedRequestEntitlementV2 = { _,_,_,callback in
+                    
+                    
                     var json = PlaybackEntitlement.requiedJson
                     json["mediaLocator"] = pipe
+                    
+                    /* var bookmarks: [String : Any] = [
+                        "liveTime" : 10,
+                        "lastViewedOffset" : 10,
+                        "lastViewedTime" : 10
+                    ] */
+                    
                     if let offset = lastViewedOffset {
                         json["lastViewedOffset"] = offset
+                        //bookmarks["lastViewedOffset"] = offset
                     }
                     if let offset = lastViewedTime {
                         json["lastViewedTime"] = offset
+                        //bookmarks["lastViewedTime"] = offset
                     }
-                    callback(json.decode(PlaybackEntitlement.self), nil, nil)
+
+                    callback(json.decode(PlaybackEntitlement.self), PlayBackEntitlementV2.requiedJson.decode(PlayBackEntitlementV2.self),nil, nil)
                 }
+                
                 return AssetPlayable(assetId: "assetId", entitlementProvider: provider)
             }
             

--- a/ExposurePlaybackTests/StartTime/ChannelSourceSpec+StartTime.swift
+++ b/ExposurePlaybackTests/StartTime/ChannelSourceSpec+StartTime.swift
@@ -33,16 +33,40 @@ class ChannelSourceStartTimeSpec: QuickSpec {
             func generatePlayable(pipe: String = "file://play/.isml", lastViewedOffset: Int? = nil, lastViewedTime: Int64? = nil) -> ChannelPlayable {
                 // Configure the playable
                 let provider = MockedChannelEntitlementProvider()
-                provider.mockedRequestEntitlement = { _,_,_, callback in
+                provider.mockedRequestEntitlementV2 = { _,_,_, callback in
                     var json = PlaybackEntitlement.requiedJson
                     json["mediaLocator"] = pipe
+                    
+                    //PlayBack Entitlement V2 Booksmarks
+                    var bookmarks: [String : Any] = [
+                        "liveTime" : 10,
+                        "lastViewedOffset" : 10,
+                        "lastViewedTime" : 10
+                    ]
+                    
                     if let offset = lastViewedOffset {
                         json["lastViewedOffset"] = offset
+                        bookmarks["lastViewedOffset"] = offset
                     }
                     if let offset = lastViewedTime {
                         json["lastViewedTime"] = offset
+                        bookmarks["lastViewedTime"] = offset
                     }
-                    callback(json.decode(PlaybackEntitlement.self), nil, nil)
+                    
+                    // Live will be true for a channel
+                    let streamInfo: [String: Any] = [
+                        "live" : true,
+                        "static" : false,
+                        "event" : false,
+                        "start" : 0,
+                        "channelId" : "channelId",
+                        "programId" : "programId"
+                    ]
+                    var entitlementVersion2Json = PlayBackEntitlementV2.requiedJson
+                    entitlementVersion2Json["streamInfo"] = streamInfo
+                    entitlementVersion2Json["bookmarks"] = bookmarks
+                    
+                    callback(json.decode(PlaybackEntitlement.self), entitlementVersion2Json.decode(PlayBackEntitlementV2.self), nil, nil)
                 }
                 return ChannelPlayable(assetId: "assetId", entitlementProvider: provider)
             }

--- a/RefApp/Navigation/MainNavigationController.swift
+++ b/RefApp/Navigation/MainNavigationController.swift
@@ -21,7 +21,7 @@ class MainNavigationController: UINavigationController {
         self.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: ColorState.active.textFieldPlaceholder]
         
         if StorageProvider.storedSessionToken != nil {
-            let assetlistViewController = AssetListTableViewController()
+            let assetlistViewController = SelectionTableViewController()
             viewControllers = [assetlistViewController]
         } else {
             perform(#selector(showLoginController), with: nil, afterDelay: 0.01)

--- a/RefApp/ViewControllers/AssetListTableViewController.swift
+++ b/RefApp/ViewControllers/AssetListTableViewController.swift
@@ -168,7 +168,7 @@ extension AssetListTableViewController {
     }
     
     
-    /// Handle the playing a channel : ChannelPlayable or AssetPlayable
+    /// Handle the play : ChannelPlayable or AssetPlayable
     ///
     /// - Parameters:
     ///   - playable: channelPlayable / AssetPlayable

--- a/RefApp/ViewControllers/AssetListTableViewController.swift
+++ b/RefApp/ViewControllers/AssetListTableViewController.swift
@@ -12,6 +12,7 @@ import ExposurePlayback
 
 class AssetListTableViewController: UITableViewController {
     
+    var selectedAsssetType: String!
     var assets = [Asset]()
     var sessionToken: SessionToken?
     
@@ -31,20 +32,8 @@ class AssetListTableViewController: UITableViewController {
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellId)
         tableView.tableFooterView = UIView()
         tableView.backgroundColor = ColorState.active.background
-        
-        addLogoutBarButtonItem()
+
         self.generateTableViewContent()
-    }
-    
-    /// Add left bar button item
-    fileprivate func addLogoutBarButtonItem() {
-        let button = UIButton()
-        button.addTarget(self, action:#selector(handleLogout), for: .touchUpInside)
-        button.setTitle(NSLocalizedString("Logout", comment: ""), for: .normal)
-        button.setTitleColor(UIColor.white, for: .normal)
-        button.sizeToFit()
-        let barButton = UIBarButtonItem(customView: button)
-        self.navigationItem.leftBarButtonItem = barButton
     }
 }
 
@@ -54,11 +43,18 @@ extension AssetListTableViewController {
     /// Generate tableview content by loading assets from API
     fileprivate func generateTableViewContent() {
         guard let environment = StorageProvider.storedEnvironment, let _ = StorageProvider.storedSessionToken else {
-            logoutUser()
+            
+            let okAction = UIAlertAction(title: NSLocalizedString("Ok", comment: ""), style: .cancel, handler: {
+                (alert: UIAlertAction!) -> Void in
+                
+            })
+            
+            let message = "Invalid Session Token, please login again"
+            self.popupAlert(title: "Error" , message: message, actions: [okAction], preferedStyle: .alert)
             return
         }
         
-        let query = "assetType=TV_CHANNEL" // MOVIE / TV_CHANNEL
+        let query = "assetType=" + selectedAsssetType // MOVIE / TV_CHANNEL
         loadAssets(query: query, environment: environment, endpoint: "/content/asset", method: HTTPMethod.get)
     }
     
@@ -67,7 +63,7 @@ extension AssetListTableViewController {
     /// - Parameters:
     ///   - query: The optional query to filter by Ex:assetType=TV_CHANNEL
     ///   - environment: Customer specific *Exposure* environment
-    ///   - endpoint: Base exposure url. This is the customer specific URL to Exposure
+    ///   - endpoint: Base exposure url. This isStaticCachupAsLiveis the customer specific URL to Exposure
     ///   - method: http method - GET
     fileprivate func loadAssets(query: String, environment: Environment, endpoint: String, method: HTTPMethod) {
         ExposureApi<AssetList>(environment: environment,
@@ -104,6 +100,8 @@ extension AssetListTableViewController {
         self.tableView.dataSource = self.datasource
         self.tableView.reloadData()
     }
+    
+    
 }
 
 
@@ -112,10 +110,73 @@ extension AssetListTableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         
         let asset = assets[indexPath.row]
+        
+        if let type = asset.type {
+            switch type {
+            case "LIVE_EVENT":
+                let playable = AssetPlayable(assetId: asset.assetId)
+                self.handlePlay(playable: playable, asset: asset)
+                
+            case "TV_CHANNEL":
+                self.showOptions(asset: asset)
+            case "MOVIE":
+                let playable = AssetPlayable(assetId: asset.assetId)
+                self.handlePlay(playable: playable, asset: asset)
+
+            default:
+                let playable = AssetPlayable(assetId: asset.assetId)
+                self.handlePlay(playable: playable, asset: asset)
+
+                break
+            }
+        }
+        
+    }
+    
+    
+    
+    /// Show options for the channel: Play using AssetPlay / ChannelPlay or Navigate to EPG View
+    ///
+    /// - Parameter asset: asset
+    fileprivate func showOptions(asset: Asset) {
+        
+        let message = "Choose option"
+        
+        let playChannelPlayable = UIAlertAction(title: "Play Channel Using Channel Playable - Test Only", style: .default, handler: {
+            (alert: UIAlertAction!) -> Void in
+            let playable = ChannelPlayable(assetId: asset.assetId)
+            self.handlePlay(playable: playable, asset: asset)
+           
+        })
+        
+        let playAssetPlayable = UIAlertAction(title: "Play Channel Using Asset Playable", style: .default, handler: {
+            (alert: UIAlertAction!) -> Void in
+            let playable = AssetPlayable(assetId: asset.assetId)
+            self.handlePlay(playable: playable, asset: asset)
+        })
+        
+        let gotoEPG = UIAlertAction(title: "Go to EPG View", style: .default, handler: {
+            (alert: UIAlertAction!) -> Void in
+            self.showEPGView(asset: asset)
+        })
+        
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: {
+            (alert: UIAlertAction!) -> Void in
+        })
+        
+        self.popupAlert(title: nil, message: message, actions: [playAssetPlayable, playChannelPlayable, gotoEPG, cancelAction], preferedStyle: .actionSheet)
+    }
+    
+    
+    /// Handle the playing a channel : ChannelPlayable or AssetPlayable
+    ///
+    /// - Parameters:
+    ///   - playable: channelPlayable / AssetPlayable
+    ///   - asset: asset
+    func handlePlay(playable : Playable, asset: Asset) {
         let destinationViewController = PlayerViewController()
         destinationViewController.environment = StorageProvider.storedEnvironment
         destinationViewController.sessionToken = StorageProvider.storedSessionToken
-        destinationViewController.channel = asset
         
         /// Optional playback properties
         let properties = PlaybackProperties(autoplay: true,
@@ -124,77 +185,17 @@ extension AssetListTableViewController {
                                             maxBitrate: 300000)
         
         destinationViewController.playbackProperties = properties
-        
-        if let type = asset.type {
-            switch type {
-            case "LIVE_EVENT":
-                destinationViewController.playable = ChannelPlayable(assetId: asset.assetId)
-            case "TV_CHANNEL":
-                destinationViewController.playable = ChannelPlayable(assetId: asset.assetId)
-            case "MOVIE":
-                destinationViewController.playable = AssetPlayable(assetId: asset.assetId)
-            default:
-                destinationViewController.playable = AssetPlayable(assetId: asset.assetId)
-                break
-            }
-        }
+        destinationViewController.playable = playable
         
         self.navigationController?.pushViewController(destinationViewController, animated: false)
-        tableView.deselectRow(at: indexPath, animated: true)
-    }
-}
-
-
-// MARK: - Actions
-extension AssetListTableViewController {
-    
-    /// User confirmation for logout
-    @objc fileprivate func handleLogout() {
-        let title = NSLocalizedString("Log out", comment: "")
-        let message = NSLocalizedString("Do you want to log out from the application ?", comment: "")
-        
-        let logOutAction = UIAlertAction(title: NSLocalizedString("Yes", comment: ""), style: UIAlertAction.Style.default, handler: { alert -> Void in
-            self.logoutUser()
-        })
-        
-        let cancelAction = UIAlertAction(title: NSLocalizedString("No", comment: ""), style: UIAlertAction.Style.default, handler: {
-            (action : UIAlertAction!) -> Void in })
-        
-        self.popupAlert(title: title, message: message, actions: [logOutAction, cancelAction])
     }
     
-    /// Log out the user from the application
-    fileprivate func logoutUser() {
-        
-        let navigationController = MainNavigationController()
-        
-        guard let environment = StorageProvider.storedEnvironment, let sessionToken = StorageProvider.storedSessionToken else {
-            self.present(navigationController, animated: true, completion: nil)
-            return
-        }
-        
-        Authenticate(environment: environment)
-            .logout(sessionToken: sessionToken)
-            .request()
-            .validate()
-            .responseData{ data, error in
-                if let error = error {
-                    let okAction = UIAlertAction(title: NSLocalizedString("Ok", comment: ""), style: .cancel, handler: {
-                        (alert: UIAlertAction!) -> Void in
-                        
-                        StorageProvider.store(environment: nil)
-                        StorageProvider.store(sessionToken: nil)
-                        self.present(navigationController, animated: true, completion: nil)
-                    })
-                    
-                    let message = "\(error.code) " + error.message + "\n" + (error.info ?? "")
-                    self.popupAlert(title: error.domain , message: message, actions: [okAction], preferedStyle: .alert)
-                }
-                else {
-                    StorageProvider.store(environment: nil)
-                    StorageProvider.store(sessionToken: nil)
-                    self.present(navigationController, animated: true, completion: nil)
-                }
-        }
+    
+    /// Navigate to EPG View
+    func showEPGView(asset: Asset) {
+        let destinationViewController = EPGListViewController()
+        destinationViewController.channel = asset
+        self.navigationController?.pushViewController(destinationViewController, animated: false)
     }
+
 }

--- a/RefApp/ViewControllers/EPGListViewController.swift
+++ b/RefApp/ViewControllers/EPGListViewController.swift
@@ -1,0 +1,186 @@
+//
+//  EPGListViewController.swift
+//  RefApp
+//
+//  Created by Udaya Sri Senarathne on 2019-05-06.
+//  Copyright © 2019 emp. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import Exposure
+import ExposurePlayback
+
+
+class EPGListViewController: UITableViewController  {
+    
+    var programs = [Program]()
+    var channel: Asset!
+    let cellIdentifier = "cellIdentifier"
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
+        tableView.tableFooterView = UIView()
+        tableView.backgroundColor = ColorState.active.background
+        
+        
+        self.generateTableViewContent()
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return self.programs.count
+    }
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
+        
+        let program = self.programs[indexPath.row]
+        let current = Date()
+        
+        if let start = program.startDate, let _ = program.endDate {
+            if start > current {
+                cell.isUserInteractionEnabled = false
+                //cell.backgroundColor = ColorState.active.textFieldPlaceholder
+                cell.textLabel?.textColor = ColorState.active.textFieldPlaceholder
+            } else {
+                cell.isUserInteractionEnabled = true
+                cell.backgroundColor = ColorState.active.background
+                cell.textLabel?.textColor = ColorState.active.text
+            }
+        }
+        
+        cell.textLabel?.text = self.programs[indexPath.row].programId
+        cell.selectionStyle = .none
+        return cell
+    }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let program = self.programs[indexPath.row]
+        let current = Date()
+        if let start = program.startDate, let _ = program.endDate {
+            if start <= current {
+                self.showOptions(program: program, channel: channel)
+            }
+        }
+        
+       
+    }
+}
+
+extension EPGListViewController {
+    
+    
+    /// Show options: Play Using ProgramPlayable or AssetPlayable
+    ///
+    /// - Parameters:
+    ///   - program: program
+    ///   - channel: channel
+    fileprivate func showOptions(program: Program, channel: Asset) {
+        
+        let message = "Choose option"
+        
+        let playProgramPlayable = UIAlertAction(title: "Play Program Using Program Playable - Test Only", style: .default, handler: {
+            (alert: UIAlertAction!) -> Void in
+            let playable = ProgramPlayable(assetId: program.programId, channelId: channel.assetId)
+            self.handleProgramPlay(playable: playable, asset: channel)
+            
+        })
+        
+        let playAssetPlayable = UIAlertAction(title: "Play Program Using Asset Playable", style: .default, handler: {
+            (alert: UIAlertAction!) -> Void in
+            let playable = AssetPlayable(assetId: program.assetId)
+            self.handleProgramPlay(playable: playable, asset: channel)
+        })
+        
+        
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: {
+            (alert: UIAlertAction!) -> Void in
+        })
+        
+        self.popupAlert(title: nil, message: message, actions: [playAssetPlayable ,playProgramPlayable, cancelAction], preferedStyle: .actionSheet)
+    }
+    
+    func handleProgramPlay(playable : Playable, asset: Asset) {
+        let destinationViewController = PlayerViewController()
+        destinationViewController.environment = StorageProvider.storedEnvironment
+        destinationViewController.sessionToken = StorageProvider.storedSessionToken
+        
+        /// Optional playback properties
+        let properties = PlaybackProperties(autoplay: true,
+                                            playFrom: .bookmark,
+                                            language: .custom(text: "fr", audio: "en"),
+                                            maxBitrate: 300000)
+        
+        destinationViewController.playbackProperties = properties
+        destinationViewController.playable = playable
+        
+        self.navigationController?.pushViewController(destinationViewController, animated: false)
+    }
+}
+
+// MARK: - DataSource
+extension EPGListViewController {
+    
+    /// Generate tableview content by loading assets from API
+    fileprivate func generateTableViewContent() {
+        guard let environment = StorageProvider.storedEnvironment, let sessionToken = StorageProvider.storedSessionToken else {
+            let okAction = UIAlertAction(title: NSLocalizedString("Ok", comment: ""), style: .cancel, handler: {
+                (alert: UIAlertAction!) -> Void in
+                
+            })
+            
+            let message = "Invalid Session Token, please login again"
+            self.popupAlert(title: "Error" , message: message, actions: [okAction], preferedStyle: .alert)
+            return
+        }
+        
+       
+        let date = Date()
+        let start = (date.subtract(days: 1) ?? date).millisecondsSince1970
+        let end = (date.add(hours: 4) ?? date).millisecondsSince1970
+        
+        fetchEpg(for: channel, from: start, to: end, environment: environment, sessionToken: sessionToken) { [weak self] epg, error in
+            guard let `self` = self else { return }
+            
+            if let error = error {
+                let okAction = UIAlertAction(title: NSLocalizedString("Ok", comment: ""), style: .cancel, handler: {
+                    (alert: UIAlertAction!) -> Void in
+                })
+                let message = "\(error.code) " + error.message + "\n" + (error.info ?? "")
+                self.popupAlert(title: error.domain , message: message, actions: [okAction], preferedStyle: .alert)
+            }
+            
+            self.programs = epg?.programs ?? []
+            self.tableView.reloadData()
+        }
+        
+    }
+    
+    
+    /// Fetch EPG
+    ///
+    /// - Parameters:
+    ///   - channel: channel
+    ///   - start: start time
+    ///   - end: <#end description#>
+    ///   - environment: environment
+    ///   - sessionToken: session token
+    ///   - callback: callback
+    fileprivate func fetchEpg(for channel: Asset, from start: Int64, to end: Int64, environment: Environment, sessionToken: SessionToken, callback: @escaping (ChannelEpg?, ExposureError?) -> Void) {
+        // Fetch Epg
+        let query = "onlyPublished=true&includeUserData=\(sessionToken != nil)&fieldSet=ALL&pageSize=500&pageNumber=1&from=\(start)&to=\(end)"
+        
+        ExposureApi<Exposure.ChannelEpg>(environment: environment, endpoint: "/epg/"+channel.assetId, query: query, method: .get, sessionToken: sessionToken)
+            .request()
+            .validate()
+            .response{
+                callback($0.value,$0.error)
+        }
+    }
+}
+

--- a/RefApp/ViewControllers/EPGListViewController.swift
+++ b/RefApp/ViewControllers/EPGListViewController.swift
@@ -167,15 +167,17 @@ extension EPGListViewController {
     /// - Parameters:
     ///   - channel: channel
     ///   - start: start time
-    ///   - end: <#end description#>
+    ///   - end: end time
     ///   - environment: environment
     ///   - sessionToken: session token
     ///   - callback: callback
     fileprivate func fetchEpg(for channel: Asset, from start: Int64, to end: Int64, environment: Environment, sessionToken: SessionToken, callback: @escaping (ChannelEpg?, ExposureError?) -> Void) {
         // Fetch Epg
-        let query = "onlyPublished=true&includeUserData=\(sessionToken != nil)&fieldSet=ALL&pageSize=500&pageNumber=1&from=\(start)&to=\(end)"
         
-        ExposureApi<Exposure.ChannelEpg>(environment: environment, endpoint: "/epg/"+channel.assetId, query: query, method: .get, sessionToken: sessionToken)
+        FetchEpg(environment: environment)
+            .channel(id: channel.assetId)
+            .filter(starting: start, ending: end)
+            .filter(onlyPublished: true)
             .request()
             .validate()
             .response{

--- a/RefApp/ViewControllers/LoginViewController.swift
+++ b/RefApp/ViewControllers/LoginViewController.swift
@@ -178,7 +178,8 @@ extension LoginViewController {
                     
                     let rootViewController = UIApplication.shared.keyWindow?.rootViewController
                     guard let mainNavigationController = rootViewController as? MainNavigationController else { return }
-                    mainNavigationController.viewControllers = [AssetListTableViewController()]
+                    // mainNavigationController.viewControllers = [AssetListTableViewController()]
+                    mainNavigationController.viewControllers = [SelectionTableViewController()]
                     self?.dismiss(animated: true, completion: nil)
                 }
         }

--- a/RefApp/ViewControllers/SelectionTableViewController.swift
+++ b/RefApp/ViewControllers/SelectionTableViewController.swift
@@ -1,0 +1,116 @@
+//
+//  SelectionTableVIewController.swift
+//  RefApp
+//
+//  Created by Udaya Sri Senarathne on 2019-05-06.
+//  Copyright © 2019 emp. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import Exposure
+
+class SelectionTableViewController: UITableViewController {
+   
+    var sections = ["MOVIE", "TV_CHANNEL", "LIVE_EVENT"]
+    let cellIdentifier = "cellIdentifier"
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.title = "Select Asset Type"
+        tableView.backgroundColor = ColorState.active.background
+        tableView.tableFooterView = UIView()
+        addLogoutBarButtonItem()
+        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
+    }
+    
+    /// Add left bar button item
+    fileprivate func addLogoutBarButtonItem() {
+        let button = UIButton()
+        button.addTarget(self, action:#selector(handleLogout), for: .touchUpInside)
+        button.setTitle(NSLocalizedString("Logout", comment: ""), for: .normal)
+        button.setTitleColor(UIColor.white, for: .normal)
+        button.sizeToFit()
+        let barButton = UIBarButtonItem(customView: button)
+        self.navigationItem.leftBarButtonItem = barButton
+    }
+    
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+       return sections.count
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
+        cell.textLabel?.text = sections[indexPath.row]
+        cell.selectionStyle = .none
+        cell.backgroundColor = ColorState.active.background
+        cell.textLabel?.textColor = ColorState.active.text
+        
+        return cell
+    }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let destinationViewController = AssetListTableViewController()
+        destinationViewController.selectedAsssetType = sections[indexPath.row]
+        self.navigationController?.pushViewController(destinationViewController, animated: false)
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
+extension SelectionTableViewController {
+    
+    /// User confirmation for logout
+    @objc fileprivate func handleLogout() {
+        let title = NSLocalizedString("Log out", comment: "")
+        let message = NSLocalizedString("Do you want to log out from the application ?", comment: "")
+        
+        let logOutAction = UIAlertAction(title: NSLocalizedString("Yes", comment: ""), style: UIAlertAction.Style.default, handler: { alert -> Void in
+            self.logoutUser()
+        })
+        
+        let cancelAction = UIAlertAction(title: NSLocalizedString("No", comment: ""), style: UIAlertAction.Style.default, handler: {
+            (action : UIAlertAction!) -> Void in })
+        
+        self.popupAlert(title: title, message: message, actions: [logOutAction, cancelAction])
+    }
+    
+    /// Log out the user from the application
+    func logoutUser() {
+        
+        let navigationController = MainNavigationController()
+        
+        guard let environment = StorageProvider.storedEnvironment, let sessionToken = StorageProvider.storedSessionToken else {
+            self.present(navigationController, animated: true, completion: nil)
+            return
+        }
+        
+        Authenticate(environment: environment)
+            .logout(sessionToken: sessionToken)
+            .request()
+            .validate()
+            .responseData{ data, error in
+                if let error = error {
+                    let okAction = UIAlertAction(title: NSLocalizedString("Ok", comment: ""), style: .cancel, handler: {
+                        (alert: UIAlertAction!) -> Void in
+                        
+                        StorageProvider.store(environment: nil)
+                        StorageProvider.store(sessionToken: nil)
+                        self.present(navigationController, animated: true, completion: nil)
+                    })
+                    
+                    let message = "\(error.code) " + error.message + "\n" + (error.info ?? "")
+                    self.popupAlert(title: error.domain , message: message, actions: [okAction], preferedStyle: .alert)
+                }
+                else {
+                    StorageProvider.store(environment: nil)
+                    StorageProvider.store(sessionToken: nil)
+                    self.present(navigationController, animated: true, completion: nil)
+                }
+        }
+    }
+}


### PR DESCRIPTION
SDK Now use playback entitlement V2
App developers can now use AssetPlayable for all asset types : VOD / Programs / Channel / Live events etc
Update reference app
Update unit tests
 