### PR TITLE
Emp 14239 - Update Reference app 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 * `2.0.78` Release - [2.0.78](#2078)
 * `0.77.x` Releases - [0.77.0](#0770)
 
+## 2.1.130
+
+#### Changes
+* `EMP-14239` Updated reference app to use AssetType enum.
+
 ## 2.1.00
 * Released 31 January 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ## 2.1.130
 
 #### Changes
+* `EMP-14239` Add option to pass assetType when creating AssetPlayable
 * `EMP-14239` Updated reference app to use AssetType enum.
 
 ## 2.1.00

--- a/ExposurePlayback.xcodeproj/project.pbxproj
+++ b/ExposurePlayback.xcodeproj/project.pbxproj
@@ -1674,7 +1674,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.1.00;
+				MARKETING_VERSION = 2.1.130;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = ExposurePlayback;
 				SDKROOT = appletvos;
@@ -1699,7 +1699,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.1.00;
+				MARKETING_VERSION = 2.1.130;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = ExposurePlayback;
 				SDKROOT = appletvos;
@@ -1917,7 +1917,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.1.00;
+				MARKETING_VERSION = 2.1.130;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = ExposurePlayback;
 				SKIP_INSTALL = YES;
@@ -1940,7 +1940,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.1.00;
+				MARKETING_VERSION = 2.1.130;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = ExposurePlayback;
 				SKIP_INSTALL = YES;

--- a/ExposurePlayback/Context/Playable/AssetPlayable.swift
+++ b/ExposurePlayback/Context/Playable/AssetPlayable.swift
@@ -19,6 +19,7 @@ internal protocol AssetEntitlementProvider {
 public struct AssetPlayable: Playable {
     /// The asset id
     public let assetId: String
+    public let assetType: AssetType?
     
     internal var entitlementProvider: AssetEntitlementProvider = ExposureEntitlementProvider()
     
@@ -76,8 +77,9 @@ public struct AssetPlayable: Playable {
 }
 
 extension AssetPlayable {
-    public init(assetId: String) {
+    public init(assetId: String, assetType: AssetType? = nil ) {
         self.assetId = assetId
+        self.assetType = assetType
     }
 }
 

--- a/ExposurePlayback/Context/Playable/ChannelPlayable.swift
+++ b/ExposurePlayback/Context/Playable/ChannelPlayable.swift
@@ -9,9 +9,6 @@
 import Foundation
 import Exposure
 
-
-
-/// This should be deprecated when the all customers ( Thuis ) moved to AssetPlayable()
 internal protocol ChannelEntitlementProvider {
     
     func requestEntitlement(channelId: String, using sessionToken: SessionToken, in environment: Environment, callback: @escaping (PlaybackEntitlement?, ExposureError?, HTTPURLResponse?) -> Void)
@@ -19,6 +16,7 @@ internal protocol ChannelEntitlementProvider {
     func requestEntitlementV2(channelId: String, using sessionToken: SessionToken, in environment: Environment, callback: @escaping (PlaybackEntitlement?, PlayBackEntitlementV2?, ExposureError?, HTTPURLResponse?) -> Void)
 }
 
+@available(*, deprecated, message: "You can use AssetPlayable & pass assetType if needed")
 /// Defines a `Playable` for the specific channel. Will play the currently live program
 public struct ChannelPlayable: Playable {
     /// The channel id

--- a/ExposurePlayback/Context/Playable/ProgramPlayable.swift
+++ b/ExposurePlayback/Context/Playable/ProgramPlayable.swift
@@ -15,6 +15,7 @@ internal protocol ProgramEntitlementProvider {
     func requestEntitlementV2(programId: String, channelId: String, using sessionToken: SessionToken, in environment: Environment, callback: @escaping (PlaybackEntitlement?, PlayBackEntitlementV2?, ExposureError?, HTTPURLResponse?) -> Void)
 }
 
+@available(*, deprecated, message: "You can use AssetPlayable & pass assetType if needed")
 /// Defines a `Playable` for the specific program
 public struct ProgramPlayable: Playable {
     /// The program Id for the program

--- a/RefApp/ViewControllers/AssetListTableViewController.swift
+++ b/RefApp/ViewControllers/AssetListTableViewController.swift
@@ -197,13 +197,13 @@ extension AssetListTableViewController {
         
         if let type = asset.type {
             switch type {
-            case "LIVE_EVENT":
+            case AssetType.LIVE_EVENT:
                 let playable = AssetPlayable(assetId: asset.assetId)
                 self.handlePlay(playable: playable, asset: asset)
                 
-            case "TV_CHANNEL":
+            case AssetType.TV_CHANNEL:
                 self.showOptions(asset: asset)
-            case "MOVIE":
+            case AssetType.MOVIE:
                 let playable = AssetPlayable(assetId: asset.assetId)
                 self.handlePlay(playable: playable, asset: asset)
 


### PR DESCRIPTION
Update the reference app to use `AssetType` in exposure
Now developers can pass `AssetType` when creating `AssetPlayable` if needed