### PR TITLE
feat: ProgramID and AssetID for VirtualChannels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+* `3.7.0` Release - [3.7.0](#370)
 * `3.6.1` Release - [3.6.1](#361)
 * `3.6.0` Release - [3.6.0](#360)
 * `3.5.1` Release - [3.5.1](#351)
@@ -63,6 +64,10 @@
 * `2.0.79` Release - [2.0.79](#2079)
 * `2.0.78` Release - [2.0.78](#2078)
 * `0.77.x` Releases - [0.77.0](#0770)
+
+## 3.7.0
+#### Feature
+* `EMP-21056` New property has been added; `ProgramAssetId`, which contains the assetId for the program, to the analytics event `Playback.ProgramChanged`
 
 ## 3.6.1
 #### Bug Fixes

--- a/Sources/iOSClientExposurePlayback/Events/ProgramChanged.swift
+++ b/Sources/iOSClientExposurePlayback/Events/ProgramChanged.swift
@@ -28,6 +28,8 @@ extension Playback {
         /// Example: 1458835_IkCMxd
         let programId: String
         
+        let programAssetId: String
+        
         /// Length in milliseconds of this program, according to the EPG
         let videoLength: Int64?
         
@@ -35,14 +37,16 @@ extension Playback {
         
         internal var analyticsInfo: AnalyticsFromEntitlement?
         
-        internal init(timestamp: Int64, offsetTime: Int64?, programId: String, videoLength: Int64? = nil, cdnInfo: CDNInfoFromEntitlement? = nil , analyticsInfo: AnalyticsFromEntitlement? = nil) {
+        internal init(timestamp: Int64, offsetTime: Int64?, programId: String, programAssetId: String, videoLength: Int64? = nil, cdnInfo: CDNInfoFromEntitlement? = nil , analyticsInfo: AnalyticsFromEntitlement? = nil) {
             self.timestamp = timestamp
             self.offsetTime = offsetTime
             self.programId = programId
+            self.programAssetId = programAssetId
             self.videoLength = videoLength
             
             self.cdnInfo = cdnInfo
             self.analyticsInfo = analyticsInfo
+            
         }
     }
 }
@@ -64,6 +68,7 @@ extension Playback.ProgramChanged: AnalyticsEvent {
             JSONKeys.eventType.rawValue: eventType,
             JSONKeys.timestamp.rawValue: timestamp,
             JSONKeys.programId.rawValue: programId,
+            JSONKeys.programAssetId.rawValue: programAssetId,
             JSONKeys.player.rawValue: player,
             
             JSONKeys.deviceId.rawValue: device.deviceId,
@@ -108,6 +113,7 @@ extension Playback.ProgramChanged: AnalyticsEvent {
         case timestamp = "Timestamp"
         case offsetTime = "OffsetTime"
         case programId = "ProgramId"
+        case programAssetId = "ProgramAssetId"
         case videoLength = "VideoLength"
         case player = "Player"
         

--- a/Sources/iOSClientExposurePlayback/Services/ExposureAnalytics.swift
+++ b/Sources/iOSClientExposurePlayback/Services/ExposureAnalytics.swift
@@ -346,19 +346,31 @@ extension ExposureAnalytics: ExposureStreamingAnalyticsProvider {
     }
     
     public func onProgramChanged<Tech, Source>(tech: Tech, source: Source, program: Program?, analytics: AnalyticsFromEntitlement?) where Tech: PlaybackTech, Source: MediaSource {
-        if let programId = program?.programId, lastKnownProgramId != nil {
+        
+        print(" On Program changed ==>>> " , program )
+        
+        if let programId = program?.programId, lastKnownProgramId != nil, let programAssetId = program?.assetId {
             
             if let source = source as? ExposureSource {
                 let event = Playback.ProgramChanged(timestamp: Date().millisecondsSince1970,
                                                     offsetTime: offsetTime(for: source, using: tech),
                                                     programId: programId,
+                                                    programAssetId: programAssetId,
                                                     videoLength: tech.duration, cdnInfo: source.entitlement.cdn, analyticsInfo: source.entitlement.analytics)
+                
+                print(" Event ExposureSource " , event )
+                
+                
                 dispatcher?.enqueue(event: event)
             } else {
                 let event = Playback.ProgramChanged(timestamp: Date().millisecondsSince1970,
                                                     offsetTime: offsetTime(for: source, using: tech),
                                                     programId: programId,
+                                                    programAssetId: programAssetId,
                                                     videoLength: tech.duration)
+                
+                print(" Event Not ExposureSource " , event )
+                
                 dispatcher?.enqueue(event: event)
             }
             

--- a/Sources/iOSClientExposurePlayback/Services/ExposureAnalytics.swift
+++ b/Sources/iOSClientExposurePlayback/Services/ExposureAnalytics.swift
@@ -346,9 +346,7 @@ extension ExposureAnalytics: ExposureStreamingAnalyticsProvider {
     }
     
     public func onProgramChanged<Tech, Source>(tech: Tech, source: Source, program: Program?, analytics: AnalyticsFromEntitlement?) where Tech: PlaybackTech, Source: MediaSource {
-        
-        print(" On Program changed ==>>> " , program )
-        
+
         if let programId = program?.programId, lastKnownProgramId != nil, let programAssetId = program?.assetId {
             
             if let source = source as? ExposureSource {
@@ -357,10 +355,6 @@ extension ExposureAnalytics: ExposureStreamingAnalyticsProvider {
                                                     programId: programId,
                                                     programAssetId: programAssetId,
                                                     videoLength: tech.duration, cdnInfo: source.entitlement.cdn, analyticsInfo: source.entitlement.analytics)
-                
-                print(" Event ExposureSource " , event )
-                
-                
                 dispatcher?.enqueue(event: event)
             } else {
                 let event = Playback.ProgramChanged(timestamp: Date().millisecondsSince1970,
@@ -368,9 +362,7 @@ extension ExposureAnalytics: ExposureStreamingAnalyticsProvider {
                                                     programId: programId,
                                                     programAssetId: programAssetId,
                                                     videoLength: tech.duration)
-                
-                print(" Event Not ExposureSource " , event )
-                
+
                 dispatcher?.enqueue(event: event)
             }
             

--- a/Sources/iOSClientExposurePlayback/Version.swift
+++ b/Sources/iOSClientExposurePlayback/Version.swift
@@ -8,4 +8,4 @@
 import Foundation
 
 /// Global constant for framework version
-public let ExposurePlaybackVersion = "3.6.1"
+public let ExposurePlaybackVersion = "3.7.0"

--- a/iOSClientExposurePlayback.podspec
+++ b/iOSClientExposurePlayback.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
 spec.name         = "iOSClientExposurePlayback"
-spec.version      = "3.6.1"
+spec.version      = "3.7.0"
 spec.summary      = "RedBeeMedia iOS SDK ExposurePlayback Module which combines both Exposure & Player"
 spec.homepage     = "https://github.com/EricssonBroadcastServices"
 spec.license      = { :type => "Apache", :file => "https://github.com/EricssonBroadcastServices/iOSClientExposurePlayback/blob/master/LICENSE" }

--- a/iOSClientExposurePlayback.xcodeproj/project.pbxproj
+++ b/iOSClientExposurePlayback.xcodeproj/project.pbxproj
@@ -1005,7 +1005,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = iOSClientExposurePlayback;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1035,7 +1035,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = iOSClientExposurePlayback;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1186,7 +1186,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = iOSClientExposurePlayback;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1217,7 +1217,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = iOSClientExposurePlayback;
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
New property has been added; `ProgramAssetId`, which contains the assetId for the program, to the analytics event `Playback.ProgramChanged`