### PR TITLE
Fix : inconsistency in videoLength  / duplicate offline analytics events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+* `3.7.1` Release - [3.7.1](#371)
 * `3.7.0` Release - [3.7.0](#370)
 * `3.6.1` Release - [3.6.1](#361)
 * `3.6.0` Release - [3.6.0](#360)
@@ -64,6 +65,12 @@
 * `2.0.79` Release - [2.0.79](#2079)
 * `2.0.78` Release - [2.0.78](#2078)
 * `0.77.x` Releases - [0.77.0](#0770)
+
+## 3.7.1
+#### Bug Fixes
+* `EMP-21115` Resolved the inconsistency in reporting VideoLength within `Playback.Started` events.
+* `EMP-21114` Fixed an issue related to duplicate offline analytics events
+*  Corrected the typo issue : `flushOfflineAnalytics()`
 
 ## 3.7.0
 #### Feature

--- a/Sources/iOSClientExposurePlayback/Context/Playable/EnigmaPlayable.swift
+++ b/Sources/iOSClientExposurePlayback/Context/Playable/EnigmaPlayable.swift
@@ -60,7 +60,7 @@ public struct EnigmaPlayable {
             adMediaLocator: nil,
             cdn: entitlementV2.cdn ,
             analytics: entitlementV2.analytics,
-            liveDelay: format.liveDelay, epg: entitlementV2.epg )
+            liveDelay: format.liveDelay, epg: entitlementV2.epg, durationInMs: entitlementV2.durationInMs )
         
         return (playbackEntitlement, nil)
     }

--- a/Sources/iOSClientExposurePlayback/Version.swift
+++ b/Sources/iOSClientExposurePlayback/Version.swift
@@ -8,4 +8,4 @@
 import Foundation
 
 /// Global constant for framework version
-public let ExposurePlaybackVersion = "3.7.0"
+public let ExposurePlaybackVersion = "3.7.1"

--- a/iOSClientExposurePlayback.podspec
+++ b/iOSClientExposurePlayback.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
 spec.name         = "iOSClientExposurePlayback"
-spec.version      = "3.7.0"
+spec.version      = "3.7.1"
 spec.summary      = "RedBeeMedia iOS SDK ExposurePlayback Module which combines both Exposure & Player"
 spec.homepage     = "https://github.com/EricssonBroadcastServices"
 spec.license      = { :type => "Apache", :file => "https://github.com/EricssonBroadcastServices/iOSClientExposurePlayback/blob/master/LICENSE" }
@@ -9,7 +9,7 @@ spec.documentation_url = "https://github.com/EricssonBroadcastServices/iOSClient
 spec.platforms = { :ios => "12.0", :tvos => "12.0" }
 spec.source       = { :git => "https://github.com/EricssonBroadcastServices/iOSClientExposurePlayback.git", :tag => "v#{spec.version}" }
 spec.source_files  = "Sources/iOSClientExposurePlayback/**/*.swift"
-spec.dependency 'iOSClientExposure', '~>  3.4.0'
+spec.dependency 'iOSClientExposure', '~>  3.4.1'
 spec.dependency 'iOSClientPlayer', '~>  3.2.2'
 end
 

--- a/iOSClientExposurePlayback.xcodeproj/project.pbxproj
+++ b/iOSClientExposurePlayback.xcodeproj/project.pbxproj
@@ -1005,7 +1005,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = iOSClientExposurePlayback;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1035,7 +1035,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = iOSClientExposurePlayback;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1186,7 +1186,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = iOSClientExposurePlayback;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1217,7 +1217,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = iOSClientExposurePlayback;
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
Resolved the inconsistency in reporting VideoLength within `Playback.Started` events.
Fixed an issue related to duplicate offline analytics events