### PR TITLE
feat : Align analytics properties for apps and device models.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+* `3.8.0` Release - [3.8.0](#380)
 * `3.7.1` Release - [3.7.1](#371)
 * `3.7.0` Release - [3.7.0](#370)
 * `3.6.1` Release - [3.6.1](#361)
@@ -65,6 +66,10 @@
 * `2.0.79` Release - [2.0.79](#2079)
 * `2.0.78` Release - [2.0.78](#2078)
 * `0.77.x` Releases - [0.77.0](#0770)
+
+## 3.8.0
+#### Changes
+* `EMP-21156` Align analytics properties for apps. Add new optional parameter `appVersion` that can be passed when configuring the player. 
 
 ## 3.7.1
 #### Bug Fixes

--- a/Sources/iOSClientExposurePlayback/Context/Components/HLSNative+ExposureContext+Creation.swift
+++ b/Sources/iOSClientExposurePlayback/Context/Components/HLSNative+ExposureContext+Creation.swift
@@ -20,8 +20,10 @@ extension Player where Tech == HLSNative<ExposureContext> {
     ///
     /// - parameter environment: The *Exposure* environment
     /// - parameter sessionToken: Token identifying this session
-    public convenience init(environment: Environment, sessionToken: SessionToken, appName: String? = nil ) {
-        self.init(environment: environment, sessionToken: sessionToken, analytics: ExposureAnalytics.self, appName: appName)
+    /// - parameter appName: App name
+    /// - parameter appVersion: App version
+    public convenience init(environment: Environment, sessionToken: SessionToken, appName: String? = nil, appVersion: String? = nil  ) {
+        self.init(environment: environment, sessionToken: sessionToken, analytics: ExposureAnalytics.self, appName: appName, appVersion: appVersion)
     }
     
     /// Creates and configures `Player` for use with `HLSNative` and `ExposureContext`.
@@ -29,9 +31,9 @@ extension Player where Tech == HLSNative<ExposureContext> {
     /// - parameter environment: The *Exposure* environment
     /// - parameter sessionToken: Token identifying this session
     /// - parameter analytics: The *Exposure* related `AnalyticsProvider` tasked with delivering analytics to the *EMP* backend.
-    public convenience init<Analytics: ExposureStreamingAnalyticsProvider>(environment: Environment, sessionToken: SessionToken, analytics: Analytics.Type, cdn: CDNInfoFromEntitlement? = nil , analyticsFromPlayback: AnalyticsFromEntitlement? = nil , appName: String? = nil ) {
-            let generator: (Tech.Context.Source?) -> AnalyticsProvider = { _ in return analytics.init(environment: environment, sessionToken: sessionToken, cdn: cdn, analytics: analyticsFromPlayback, appName: appName) }
-            let context = ExposureContext(environment: environment, sessionToken: sessionToken, appName: appName)
+    public convenience init<Analytics: ExposureStreamingAnalyticsProvider>(environment: Environment, sessionToken: SessionToken, analytics: Analytics.Type, cdn: CDNInfoFromEntitlement? = nil , analyticsFromPlayback: AnalyticsFromEntitlement? = nil , appName: String? = nil, appVersion: String? = nil ) {
+        let generator: (Tech.Context.Source?) -> AnalyticsProvider = { _ in return analytics.init(environment: environment, sessionToken: sessionToken, cdn: cdn, analytics: analyticsFromPlayback, appName: appName, appVersion: appVersion) }
+        let context = ExposureContext(environment: environment, sessionToken: sessionToken, appName: appName, appVersion: appVersion)
 
         let tech = HLSNative<ExposureContext>()
         tech.airplayHandler = context

--- a/Sources/iOSClientExposurePlayback/Context/ExposureContext.swift
+++ b/Sources/iOSClientExposurePlayback/Context/ExposureContext.swift
@@ -34,6 +34,8 @@ public class ExposureContext: MediaContext {
     
     public let appName: String?
     
+    public let appVersion: String?
+    
     /// Service that handles synchronization of local device time with server time
     public let monotonicTimeService: MonotonicTimeService
     
@@ -109,11 +111,14 @@ public class ExposureContext: MediaContext {
     ///
     /// - parameter environment: Exposure `Environment` to use
     /// - parameter sessionToken: Exposure `SessionToken` to use
-    public init(environment: Environment, sessionToken: SessionToken, appName: String? = nil ) {
+    /// - parameter appName: App Name
+    /// - parameter appVersion: App version
+    public init(environment: Environment, sessionToken: SessionToken, appName: String? = nil, appVersion: String? = nil ) {
         self.environment = environment
         self.sessionToken = sessionToken
         self.monotonicTimeService = MonotonicTimeService(environment: environment)
         self.appName = appName
+        self.appVersion = appVersion
         
         reachability = Reachability()
         do {

--- a/Sources/iOSClientExposurePlayback/Events/Aborted.swift
+++ b/Sources/iOSClientExposurePlayback/Events/Aborted.swift
@@ -59,7 +59,7 @@ extension Playback.Aborted: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/AdCompleted.swift
+++ b/Sources/iOSClientExposurePlayback/Events/AdCompleted.swift
@@ -62,7 +62,7 @@ extension Playback.AdCompleted: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/AdFailed.swift
+++ b/Sources/iOSClientExposurePlayback/Events/AdFailed.swift
@@ -62,7 +62,7 @@ extension Playback.AdFailed: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/AdStarted.swift
+++ b/Sources/iOSClientExposurePlayback/Events/AdStarted.swift
@@ -63,7 +63,7 @@ extension Playback.AdStarted: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/AppBackgrounded.swift
+++ b/Sources/iOSClientExposurePlayback/Events/AppBackgrounded.swift
@@ -55,7 +55,7 @@ extension Playback.AppBackgrounded: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/AppResumed.swift
+++ b/Sources/iOSClientExposurePlayback/Events/AppResumed.swift
@@ -58,7 +58,7 @@ extension Playback.AppResumed: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/BitrateChanged.swift
+++ b/Sources/iOSClientExposurePlayback/Events/BitrateChanged.swift
@@ -64,7 +64,7 @@ extension Playback.BitrateChanged: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/BufferingStarted.swift
+++ b/Sources/iOSClientExposurePlayback/Events/BufferingStarted.swift
@@ -59,7 +59,7 @@ extension Playback.BufferingStarted: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/BufferingStopped.swift
+++ b/Sources/iOSClientExposurePlayback/Events/BufferingStopped.swift
@@ -59,7 +59,7 @@ extension Playback.BufferingStopped: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/Completed.swift
+++ b/Sources/iOSClientExposurePlayback/Events/Completed.swift
@@ -60,7 +60,7 @@ extension Playback.Completed: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/ConnectionChanged.swift
+++ b/Sources/iOSClientExposurePlayback/Events/ConnectionChanged.swift
@@ -63,7 +63,7 @@ extension Playback.ConnectionChanged: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/Created.swift
+++ b/Sources/iOSClientExposurePlayback/Events/Created.swift
@@ -91,7 +91,7 @@ extension Playback.Created: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/DeviceInfo.swift
+++ b/Sources/iOSClientExposurePlayback/Events/DeviceInfo.swift
@@ -37,11 +37,13 @@ internal struct DeviceInfo {
     
     internal let appName: String?
     
+    internal let appVersion: String?
+    
     internal var cdnInfo: CDNInfoFromEntitlement?
     
     internal var analyticsInfo: AnalyticsFromEntitlement?
     
-    internal init(timestamp: Int64, connection: String, type: String? = nil, tech: String, techVersion: String,  cdnInfo: CDNInfoFromEntitlement? = nil , analyticsInfo: AnalyticsFromEntitlement? = nil, appName: String? = nil ) {
+    internal init(timestamp: Int64, connection: String, type: String? = nil, tech: String, techVersion: String,  cdnInfo: CDNInfoFromEntitlement? = nil , analyticsInfo: AnalyticsFromEntitlement? = nil, appName: String? = nil, appVersion: String? = nil) {
         self.timestamp = timestamp
         self.connection = connection
         self.type = type
@@ -52,6 +54,7 @@ internal struct DeviceInfo {
         self.cdnInfo = cdnInfo
         self.analyticsInfo = analyticsInfo
         self.appName = appName
+        self.appVersion = appVersion
     }
 }
 
@@ -76,7 +79,7 @@ extension DeviceInfo: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.connection.rawValue: connection,
@@ -87,6 +90,10 @@ extension DeviceInfo: AnalyticsEvent {
         
         if let appName = appName {
             params[JSONKeys.appName.rawValue] = appName
+        }
+        
+        if let appVersion = appVersion {
+            params[JSONKeys.appVersion.rawValue] = appVersion
         }
         
         if let cpuType = device.cpuType {
@@ -129,6 +136,8 @@ extension DeviceInfo: AnalyticsEvent {
         
         // the official name of the app
         case appName = "AppName"
+        
+        case appVersion = "AppVersion"
         
         case os = "OS"
         

--- a/Sources/iOSClientExposurePlayback/Events/DrmEvent.swift
+++ b/Sources/iOSClientExposurePlayback/Events/DrmEvent.swift
@@ -77,7 +77,7 @@ extension Playback.DRM: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/Error.swift
+++ b/Sources/iOSClientExposurePlayback/Events/Error.swift
@@ -128,7 +128,7 @@ extension Playback.Error: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: deviceId,
             JSONKeys.deviceModel.rawValue: deviceModel,
             JSONKeys.os.rawValue: os,
-            JSONKeys.appType.rawValue: os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: osVersion,
             JSONKeys.manufacturer.rawValue: manufacturer,
             JSONKeys.player.rawValue: player,

--- a/Sources/iOSClientExposurePlayback/Events/GracePeriodEnded.swift
+++ b/Sources/iOSClientExposurePlayback/Events/GracePeriodEnded.swift
@@ -55,7 +55,7 @@ extension Playback.GracePeriodEnded: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/GracePeriodStarted.swift
+++ b/Sources/iOSClientExposurePlayback/Events/GracePeriodStarted.swift
@@ -56,7 +56,7 @@ extension Playback.GracePeriodStarted: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/HandshakeStarted.swift
+++ b/Sources/iOSClientExposurePlayback/Events/HandshakeStarted.swift
@@ -62,7 +62,7 @@ extension Playback.HandshakeStarted: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/Heartbeat.swift
+++ b/Sources/iOSClientExposurePlayback/Events/Heartbeat.swift
@@ -64,7 +64,7 @@ extension Playback.Heartbeat: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/Paused.swift
+++ b/Sources/iOSClientExposurePlayback/Events/Paused.swift
@@ -58,7 +58,7 @@ extension Playback.Paused: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/PlayReady.swift
+++ b/Sources/iOSClientExposurePlayback/Events/PlayReady.swift
@@ -72,7 +72,7 @@ extension Playback.PlayReady: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/ProgramChanged.swift
+++ b/Sources/iOSClientExposurePlayback/Events/ProgramChanged.swift
@@ -74,7 +74,7 @@ extension Playback.ProgramChanged: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/Resumed.swift
+++ b/Sources/iOSClientExposurePlayback/Events/Resumed.swift
@@ -58,7 +58,7 @@ extension Playback.Resumed: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/ScrubbedTo.swift
+++ b/Sources/iOSClientExposurePlayback/Events/ScrubbedTo.swift
@@ -59,7 +59,7 @@ extension Playback.ScrubbedTo: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/StartAirplay.swift
+++ b/Sources/iOSClientExposurePlayback/Events/StartAirplay.swift
@@ -59,7 +59,7 @@ extension Playback.StartAirplay: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/StartCasting.swift
+++ b/Sources/iOSClientExposurePlayback/Events/StartCasting.swift
@@ -58,7 +58,7 @@ extension Playback.StartCasting: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/Started.swift
+++ b/Sources/iOSClientExposurePlayback/Events/Started.swift
@@ -99,7 +99,7 @@ extension Playback.Started: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/StopAirplay.swift
+++ b/Sources/iOSClientExposurePlayback/Events/StopAirplay.swift
@@ -59,7 +59,7 @@ extension Playback.StopAirplay: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/StopCasting.swift
+++ b/Sources/iOSClientExposurePlayback/Events/StopCasting.swift
@@ -58,7 +58,7 @@ extension Playback.StopCasting: AnalyticsEvent {
             JSONKeys.deviceId.rawValue: device.deviceId,
             JSONKeys.deviceModel.rawValue: device.model,
             JSONKeys.os.rawValue: device.os,
-            JSONKeys.appType.rawValue: device.os,
+            JSONKeys.appType.rawValue: "app",
             JSONKeys.osVersion.rawValue: device.osVersion,
             JSONKeys.manufacturer.rawValue: device.manufacturer,
             JSONKeys.height.rawValue: device.height,

--- a/Sources/iOSClientExposurePlayback/Events/Trace.swift
+++ b/Sources/iOSClientExposurePlayback/Events/Trace.swift
@@ -66,7 +66,7 @@ extension Playback.Trace: AnalyticsEvent {
         json[JSONKeys.deviceId.rawValue] = device.deviceId
         json[JSONKeys.deviceModel.rawValue] = device.model
         json[JSONKeys.os.rawValue] = device.os
-        json[JSONKeys.appType.rawValue] =  device.os
+        json[JSONKeys.appType.rawValue] =  "app"
         json[JSONKeys.osVersion.rawValue] = device.osVersion
         json[JSONKeys.manufacturer.rawValue] = device.manufacturer
         json[JSONKeys.height.rawValue] = device.height

--- a/Sources/iOSClientExposurePlayback/Protocols/ExposureStreamingAnalyticsProvider.swift
+++ b/Sources/iOSClientExposurePlayback/Protocols/ExposureStreamingAnalyticsProvider.swift
@@ -12,7 +12,7 @@ import iOSClientExposure
 
 /// Extends the `Player` built in protocol defining analytics events with *Exposure* specific analytics
 public protocol ExposureStreamingAnalyticsProvider: AnalyticsProvider {
-    init(environment: Environment, sessionToken: SessionToken, cdn:CDNInfoFromEntitlement? , analytics: AnalyticsFromEntitlement?, appName: String? )
+    init(environment: Environment, sessionToken: SessionToken, cdn:CDNInfoFromEntitlement? , analytics: AnalyticsFromEntitlement?, appName: String?, appVersion: String? )
     
     /// Exposure environment used for the active session.
     ///
@@ -26,6 +26,8 @@ public protocol ExposureStreamingAnalyticsProvider: AnalyticsProvider {
     
     // the official name of the app
     var appName: String? { get }
+    
+    var appVersion: String? { get }
     
     /// Sent when the player is about to make an entitlement request
     ///

--- a/Sources/iOSClientExposurePlayback/Services/ExposureAnalytics.swift
+++ b/Sources/iOSClientExposurePlayback/Services/ExposureAnalytics.swift
@@ -60,6 +60,8 @@ public class ExposureAnalytics {
     // the official name of the app
     public let appName: String?
     
+    public let appVersion: String?
+    
     /// `Dispatcher` takes care of delivering analytics payload.
     fileprivate(set) internal var dispatcher: Dispatcher?
     
@@ -72,12 +74,13 @@ public class ExposureAnalytics {
     
     internal var isOfflinePlayable: Bool = false
     
-    public required init(environment: Environment, sessionToken: SessionToken, cdn: CDNInfoFromEntitlement? = nil , analytics: AnalyticsFromEntitlement? = nil, appName: String? = nil ) {
+    public required init(environment: Environment, sessionToken: SessionToken, cdn: CDNInfoFromEntitlement? = nil , analytics: AnalyticsFromEntitlement? = nil, appName: String? = nil, appVersion: String? = nil ) {
         self.environment = environment
         self.sessionToken = sessionToken
         self.cdn = cdn
         self.analytics = analytics
         self.appName = appName
+        self.appVersion = appVersion
     }
     
     public var onExposureResponseMessage: (ExposureResponseMessage) -> Void = { _ in }
@@ -246,7 +249,7 @@ extension ExposureAnalytics: ExposureStreamingAnalyticsProvider {
             /// 2. DeviceInfo
             let connectionType = networkTech(connection: (Reachability()?.connection ?? Reachability.Connection.unknown))
             /// EMP-11647: If this is an Airplay session, set `Playback.Device.Info.type = AirPlay`
-            let deviceInfo = DeviceInfo(timestamp: Date().millisecondsSince1970, connection: connectionType, type: isAirplaySession, tech: String(describing: type(of: tech)),techVersion: version(for: techBundle), cdnInfo: source.entitlement.cdn, analyticsInfo: source.entitlement.analytics, appName: appName)
+            let deviceInfo = DeviceInfo(timestamp: Date().millisecondsSince1970, connection: connectionType, type: isAirplaySession, tech: String(describing: type(of: tech)),techVersion: version(for: techBundle), cdnInfo: source.entitlement.cdn, analyticsInfo: source.entitlement.analytics, appName: appName, appVersion: appVersion)
             
             /// 3. Store startup events
             var current = startupEvents
@@ -274,7 +277,7 @@ extension ExposureAnalytics: ExposureStreamingAnalyticsProvider {
             /// 2. DeviceInfo
             let connectionType = networkTech(connection: (Reachability()?.connection ?? Reachability.Connection.unknown))
             /// EMP-11647: If this is an Airplay session, set `Playback.Device.Info.type = AirPlay`
-            let deviceInfo = DeviceInfo(timestamp: Date().millisecondsSince1970, connection: connectionType, type: isAirplaySession, tech: String(describing: type(of: tech)),techVersion: version(for: techBundle), analyticsInfo: nil, appName: appName)
+            let deviceInfo = DeviceInfo(timestamp: Date().millisecondsSince1970, connection: connectionType, type: isAirplaySession, tech: String(describing: type(of: tech)),techVersion: version(for: techBundle), analyticsInfo: nil, appName: appName, appVersion: appVersion)
             
             /// 3. Store startup events
             var current = startupEvents
@@ -504,7 +507,7 @@ extension ExposureAnalytics: AnalyticsProvider {
             /// 1. DeviceInfo
             let connectionType = networkTech(connection: (Reachability()?.connection ?? Reachability.Connection.unknown))
             let techBundle = (tech is HLSNative<ExposureContext>) ? "com.emp.Player" : Bundle(for: type(of: tech)).bundleIdentifier
-            let deviceInfo = DeviceInfo(timestamp: Date().millisecondsSince1970, connection: connectionType, type: isAirplaySession, tech: String(describing: type(of: tech)),techVersion: version(for: techBundle), cdnInfo: source.entitlement.cdn, analyticsInfo: source.entitlement.analytics, appName: appName)
+            let deviceInfo = DeviceInfo(timestamp: Date().millisecondsSince1970, connection: connectionType, type: isAirplaySession, tech: String(describing: type(of: tech)),techVersion: version(for: techBundle), cdnInfo: source.entitlement.cdn, analyticsInfo: source.entitlement.analytics, appName: appName, appVersion: appVersion)
             events.append(deviceInfo)
             
             /// 2. Created
@@ -631,6 +634,7 @@ extension ExposureAnalytics: AnalyticsProvider {
             }
             
             let referenceTime:Int64? = source.isUnifiedPackager ? 0 : nil
+            
             let event = Playback.Started(timestamp: Date().millisecondsSince1970,
                                          assetData: PlaybackIdentifier.from(source: source, offline: tech.isOfflinePlayable),
                                          mediaLocator: source.entitlement.mediaLocator.absoluteString,

--- a/Sources/iOSClientExposurePlayback/Version.swift
+++ b/Sources/iOSClientExposurePlayback/Version.swift
@@ -8,4 +8,4 @@
 import Foundation
 
 /// Global constant for framework version
-public let ExposurePlaybackVersion = "3.7.1"
+public let ExposurePlaybackVersion = "3.8.0"

--- a/Tests/iOSClientExposurePlaybackTests/MockedExposureAnalytics.swift
+++ b/Tests/iOSClientExposurePlaybackTests/MockedExposureAnalytics.swift
@@ -14,10 +14,11 @@ import iOSClientPlayer
 
 class MockedExposureAnalytics: ExposureStreamingAnalyticsProvider {
    
-    required init(environment: Environment, sessionToken: SessionToken, cdn: CDNInfoFromEntitlement?, analytics: AnalyticsFromEntitlement?, appName: String? = nil  ) {
+    required init(environment: Environment, sessionToken: SessionToken, cdn: CDNInfoFromEntitlement?, analytics: AnalyticsFromEntitlement?, appName: String? = nil, appVersion: String? = nil   ) {
         self.environment = environment
         self.sessionToken = sessionToken
         self.appName = appName
+        self.appVersion = appVersion
         self.analytics = analytics
     }
     
@@ -28,6 +29,8 @@ class MockedExposureAnalytics: ExposureStreamingAnalyticsProvider {
     let analytics: AnalyticsFromEntitlement?
     
     let appName: String?
+    
+    let appVersion: String?
     
     func onEntitlementRequested<Tech, Source>(tech: Tech, source: Source,playable: Playable) where Tech: PlaybackTech, Source : MediaSource {
         

--- a/Tests/iOSClientExposurePlaybackTests/TestEnv.swift
+++ b/Tests/iOSClientExposurePlaybackTests/TestEnv.swift
@@ -32,7 +32,7 @@ class TestEnv {
 
         self.environment = environment
         self.sessionToken = sessionToken
-        self.player = Player<HLSNative<ExposureContext>>(environment: environment, sessionToken: sessionToken, analytics: MockedExposureAnalytics.self, appName: "Test App Name")
+        self.player = Player<HLSNative<ExposureContext>>(environment: environment, sessionToken: sessionToken, analytics: MockedExposureAnalytics.self, appName: "Test App Name", appVersion: "3.0.0")
         
         // Mock the AVPlayer
         let mockedPlayer = MockedAVPlayer()

--- a/iOSClientExposurePlayback.podspec
+++ b/iOSClientExposurePlayback.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
 spec.name         = "iOSClientExposurePlayback"
-spec.version      = "3.7.1"
+spec.version      = "3.8.0"
 spec.summary      = "RedBeeMedia iOS SDK ExposurePlayback Module which combines both Exposure & Player"
 spec.homepage     = "https://github.com/EricssonBroadcastServices"
 spec.license      = { :type => "Apache", :file => "https://github.com/EricssonBroadcastServices/iOSClientExposurePlayback/blob/master/LICENSE" }

--- a/iOSClientExposurePlayback.xcodeproj/project.pbxproj
+++ b/iOSClientExposurePlayback.xcodeproj/project.pbxproj
@@ -1005,7 +1005,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.7.1;
+				MARKETING_VERSION = 3.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = iOSClientExposurePlayback;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1035,7 +1035,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.7.1;
+				MARKETING_VERSION = 3.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = iOSClientExposurePlayback;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1186,7 +1186,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.7.1;
+				MARKETING_VERSION = 3.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = iOSClientExposurePlayback;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1217,7 +1217,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.7.1;
+				MARKETING_VERSION = 3.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.ExposurePlayback;
 				PRODUCT_NAME = iOSClientExposurePlayback;
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
- Change `appType` to always send type : `app`
- Add new optional parameter `appVersion` that can be passed when configuring the player.